### PR TITLE
Fixed typo in config.example.json

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -5,7 +5,7 @@
   },
   "keys": {
     "all": "covidapi:all",
-    "countries": "coviapi:countries"
+    "countries": "covidapi:countries"
   },
   "port": 8080,
   "interval": 600000


### PR DESCRIPTION
¯\_(ツ)_/¯