### PR TITLE
Removed first object from the historical result

### DIFF
--- a/funcs/historical.js
+++ b/funcs/historical.js
@@ -60,7 +60,8 @@ var historical = async (keys, redis) => {
     b++;
   }
   
-  const string = JSON.stringify(result);
+  const removeFirstObj = result.splice(1);
+  const string = JSON.stringify(removeFirstObj);
   redis.set(keys.historical, string);
   console.log(`Updated JHU CSSE Historical: ${result.length} locations`);
 }


### PR DESCRIPTION
Before first object of the result:

```
[
    {
        "country": "Country/Region",
        "province": "Province/State",
        "timeline": {
            "cases": {},
            "deaths": {},
            "recovered": {}
        }
    },
    ...
]
```

Now:
```
[
  {
      "country": "Thailand",
      "province": null,
      "timeline": {
          "cases": {
            ...
          },
          "deaths": {
            ...
          },
          "recovered": {
            ...
          }
        }
  },
  ...
]
```