### PR TITLE
Optimize historical/countryName endpoint

### DIFF
--- a/funcs/countryMap.js
+++ b/funcs/countryMap.js
@@ -1,0 +1,28 @@
+/**
+ * WIP country mapping for countries that could be spelled differently than what we are expecting
+ */
+const countryMapping = [
+    {possibleNames: ["us", "united states of america", "america", "united states"], standardizedName: "usa"},
+    {possibleNames: ["south korea"], standardizedName: "s. korea"},
+    {possibleNames: ["united kingdom", "england"], standardizedName: "uk"},
+    {possibleNames: ["dr"], standardizedName: "dominican republic"},
+    {possibleNames: ["united arab emirates"], standardizedName: "uae"},
+    {possibleNames: ["bosnia and herzegovina"], standardizedName: "bosnia"},
+    {possibleNames: ["virgin islands"], standardizedName: "u.s. virgin islands"},
+    {possibleNames: ["czechia"], standardizedName: "czech republic"},
+    {possibleNames: ["méxico"], standardizedName: "mexico"},
+    {possibleNames: ["brasil"], standardizedName: "brazil"},
+    {possibleNames: ["panamá"], standardizedName: "panama"},
+];
+
+/**
+ * Takes a country name and gives back the standardized name, if a change is needed
+ */
+function standardizeCountryName(countryName) {
+    const possibleMapping = countryMapping.filter(mapping => mapping.possibleNames.indexOf(countryName) >= 0);
+    return (possibleMapping.length == 1 ? possibleMapping[0].standardizedName : countryName.toLowerCase());
+}
+
+module.exports = {
+    standardizeCountryName
+}

--- a/funcs/historical.js
+++ b/funcs/historical.js
@@ -71,13 +71,15 @@ var historical = async (keys, redis) => {
  * Parses data from historical endpoint to and returns data for specific country. US requires more specialized data sanitization.
  * @param {*} data: full historical data returned from /historical endpoint
  * @param {*} country: country query param
+ * @param {*} redis: redis server in case we need state names for USA
+ * @param {*} keys: states keys for redis
  */
-async function getHistoricalCountryData(data, country) {
+async function getHistoricalCountryData(data, country, redis=null, keys=null) {
   var countryData;
   if (country == "us") {
-    // get all valid states from /states endpoint
-    const response = await axios.get(`https://corona.lmao.ninja/states`);
-    const stateData = response.data;
+    // get all valid states from redis
+    let stateData = JSON.parse(await redis.get(keys));
+    // const stateData = response.data;
     const states = stateData.map(obj => {
       return obj.state.toLowerCase();
     });

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ var cors = require('cors');
 const config = require('./config.json');
 const Redis = require('ioredis');
 const scraper = require('./scraper');
+const countryMap = require('./funcs/countryMap');
 
 app.use(cors());
 
@@ -68,8 +69,9 @@ app.get("/historical/:country", async function (req, res) {
 
 app.get("/countries/:country", async function (req, res) {
   let countries = JSON.parse(await redis.get(keys.countries))
+  const standardizedCountryName = countryMap.standardizeCountryName(req.params.country.toLowerCase());
   let country = countries.find(
-    e => e.country.toLowerCase().includes(req.params.country.toLowerCase())
+    e => e.country.toLowerCase().includes(standardizedCountryName)
   );
   if (!country) {
     res.send("Country not found");

--- a/server.js
+++ b/server.js
@@ -61,8 +61,8 @@ app.get("/historical/", async function (req, res) {
 });
 
 app.get("/historical/:country", async function (req, res) {
-  let data = JSON.parse(await redis.get(keys.historical))
-  const countryData = await scraper.historical.getHistoricalCountryData(data, req.params.country.toLowerCase());
+  let data = JSON.parse(await redis.get(keys.historical));
+  const countryData = await scraper.historical.getHistoricalCountryData(data, req.params.country.toLowerCase(), redis, keys.states);
   res.send(countryData);
 });
 


### PR DESCRIPTION
Previously `historical/USA` was querying the API to get all state names whenever `historical/USA` was requested. This PR uses Redis to make the call faster and less request intensive.