### PR TITLE
fix wrong country returning as described in issue #92

### DIFF
--- a/server.js
+++ b/server.js
@@ -71,11 +71,7 @@ app.get("/countries/:country", async function (req, res) {
   let countries = JSON.parse(await redis.get(keys.countries))
   const standardizedCountryName = countryMap.standardizeCountryName(req.params.country.toLowerCase());
   let country = countries.find(
-<<<<<<< HEAD
-    e => e.country.toLowerCase() === req.params.country.toLowerCase()
-=======
-    e => e.country.toLowerCase().includes(standardizedCountryName)
->>>>>>> 912c42ad6f377c7746e281f2b8309fee6966b2ba
+    e => e.country.toLowerCase() === standardizedCountryName
   );
   if (!country) {
     res.send("Country not found");

--- a/server.js
+++ b/server.js
@@ -69,7 +69,7 @@ app.get("/historical/:country", async function (req, res) {
 app.get("/countries/:country", async function (req, res) {
   let countries = JSON.parse(await redis.get(keys.countries))
   let country = countries.find(
-    e => e.country.toLowerCase().includes(req.params.country.toLowerCase())
+    e => e.country.toLowerCase() === req.params.country.toLowerCase()
   );
   if (!country) {
     res.send("Country not found");


### PR DESCRIPTION
When requesting the country Oman at the endpoint /countries/oman the api would return romainia because it was using .includes and romainia includes the string Oman. I changed this to only return if the country is equal to the one being requested.