### PR TITLE
2 birds one stone

### DIFF
--- a/funcs/countryMap.js
+++ b/funcs/countryMap.js
@@ -3,7 +3,7 @@
  */
 const countryMapping = [
     {possibleNames: ["us", "united states of america", "america", "united states"], standardizedName: "usa"},
-    {possibleNames: ["south korea"], standardizedName: "s. korea"},
+    {possibleNames: ["south korea", "korea, south"], standardizedName: "s. korea"},
     {possibleNames: ["united kingdom", "england"], standardizedName: "uk"},
     {possibleNames: ["dr"], standardizedName: "dominican republic"},
     {possibleNames: ["united arab emirates"], standardizedName: "uae"},

--- a/server.js
+++ b/server.js
@@ -70,9 +70,15 @@ app.get("/historical/:country", async function (req, res) {
 app.get("/countries/:country", async function (req, res) {
   let countries = JSON.parse(await redis.get(keys.countries))
   const standardizedCountryName = countryMap.standardizeCountryName(req.params.country.toLowerCase());
-  let country = countries.find(
-    e => e.country.toLowerCase().includes(standardizedCountryName)
-  );
+  let country = countries.find(e => {
+    // see if strict was even a parameter
+    if (req.query.strict) {
+      return req.query.strict.toLowerCase() == 'true' ? e.country.toLowerCase() === standardizedCountryName : e.country.toLowerCase().includes(standardizedCountryName)
+    }
+    else {
+      return e.country.toLowerCase().includes(standardizedCountryName);
+    }
+  });
   if (!country) {
     res.send("Country not found");
     return;


### PR DESCRIPTION
1. Fix the `/historical/south korea` endpoint
2. Create an optional strict param for `countries/countryName` endpoint.
You can test these changes using romania and oman, where oman without strict returns romania data, with strict returns oman data