### PR TITLE
Historical endpoint update

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ You can read more about **new Date()** [here](https://developer.mozilla.org/en-U
 > For further support, you can join our discord server! More Tutorials can be found there too!
 > https://discord.gg/EvbMshU
 
-### Source: 
+### Sources: 
 > https://www.worldometers.info/coronavirus/ 
+> https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data/csse_covid_19_time_series
 
 ## Contributors ✨
 

--- a/funcs/historical.js
+++ b/funcs/historical.js
@@ -172,11 +172,43 @@ async function getHistoricalCountryData(data, country, redis=null, keys=null) {
     standardizedCountryName,
     timeline
   });
+}
 
+/**
+ * Parses data from historical endpoint to and returns data for specific country. 
+ * @param {*} data: full historical data returned from /historical endpoint
+ * @param {*} country: country query param
+ */
+async function getHistoricalCountryData_v2(data, country) {
+  const standardizedCountryName = countryMap.standardizeCountryName(country.toLowerCase());
+  const countryData = data.filter(obj => obj.country.toLowerCase() == standardizedCountryName);
+
+  // overall timeline for country
+  const timeline = {cases: {}, deaths: {}, recovered: {}};
+  // sum over provinces
+  for (var province = 0; province < countryData.length; province++) {
+    // loop cases, recovered, deaths for each province
+    Object.keys(countryData[province].timeline).forEach(specifier => {
+      Object.keys(countryData[province].timeline[specifier]).forEach(date => {
+        if (timeline[specifier][date]) {
+          timeline[specifier][date] += parseInt(countryData[province].timeline[specifier][date]);
+        }
+        else {
+          timeline[specifier][date] = parseInt(countryData[province].timeline[specifier][date]);
+        }
+      });
+    });
+  }
+
+  return ({
+    country: standardizedCountryName,
+    timeline
+  });
 }
 
 module.exports = {
   historical,
   historical_v2,
-  getHistoricalCountryData
+  getHistoricalCountryData,
+  getHistoricalCountryData_v2
 };

--- a/funcs/historical.js
+++ b/funcs/historical.js
@@ -6,6 +6,69 @@ var base =
   "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/";
 
 var historical = async (keys, redis) => {
+  let casesResponse, deathsResponse, recResponse;
+  try {
+    casesResponse = await axios.get(
+      `${base}time_series_19-covid-Confirmed.csv`
+    );
+    deathsResponse = await axios.get(`${base}time_series_19-covid-Deaths.csv`);
+    recResponse = await axios.get(`${base}time_series_19-covid-Recovered.csv`);
+  } catch (err) {
+    console.log(err);
+    return null;
+  }
+
+  const parsedCases = await csv({
+    noheader: true,
+    output: "csv"
+  }).fromString(casesResponse.data);
+
+  const parsedDeaths = await csv({
+    noheader: true,
+    output: "csv"
+  }).fromString(deathsResponse.data);
+
+  const recParsed = await csv({
+    noheader: true,
+    output: "csv"
+  }).fromString(recResponse.data);
+
+  // to store parsed data
+  const result = [];
+  const timelineKey = parsedCases[0].splice(4);
+  // parsedCases.pop()
+  // parsedDeaths.pop()
+  // recParsed.pop()
+
+  for (let b = 0; b < parsedDeaths.length; ) {
+    const timeline = {
+      cases: {},
+      deaths: {},
+      recovered: {}
+    };
+    const c = parsedCases[b].splice(4);
+    const r = recParsed[b].splice(4);
+    const d = parsedDeaths[b].splice(4);
+    for (let i = 0; i < c.length; i++) {
+      timeline.cases[timelineKey[i]] = c[i];
+      timeline.deaths[timelineKey[i]] = d[i];
+      timeline.recovered[timelineKey[i]] = r[i];
+    }
+    result.push({
+      country: countryMap.standardizeCountryName(parsedCases[b][1].toLowerCase()),
+      province: parsedCases[b][0] === "" ? null : countryMap.standardizeCountryName(parsedCases[b][0].toLowerCase()),
+      timeline
+    });
+    b++;
+  }
+
+  const removeFirstObj = result.splice(1);
+  const string = JSON.stringify(removeFirstObj);
+  redis.set(keys.historical, string);
+  console.log(`Updated JHU CSSE Historical: ${removeFirstObj.length} locations`);
+};
+  
+var historical_v2 = async (keys, redis) => {
   let casesResponse, deathsResponse;
   try {
     casesResponse = await axios.get(`${base}time_series_covid19_confirmed_global.csv`);
@@ -52,7 +115,7 @@ var historical = async (keys, redis) => {
 
   const removeFirstObj = result.splice(1);
   const string = JSON.stringify(removeFirstObj);
-  redis.set(keys.historical, string);
+  redis.set(keys.historical_v2, string);
   console.log(`Updated JHU CSSE Historical: ${removeFirstObj.length} locations`);
 };
 
@@ -114,5 +177,6 @@ async function getHistoricalCountryData(data, country, redis=null, keys=null) {
 
 module.exports = {
   historical,
+  historical_v2,
   getHistoricalCountryData
 };

--- a/funcs/historical.js
+++ b/funcs/historical.js
@@ -184,7 +184,7 @@ async function getHistoricalCountryData_v2(data, country) {
   const countryData = data.filter(obj => obj.country.toLowerCase() == standardizedCountryName);
 
   // overall timeline for country
-  const timeline = {cases: {}, deaths: {}, recovered: {}};
+  const timeline = {cases: {}, deaths: {}};
   // sum over provinces
   for (var province = 0; province < countryData.length; province++) {
     // loop cases, recovered, deaths for each province

--- a/funcs/historical.js
+++ b/funcs/historical.js
@@ -6,13 +6,10 @@ var base =
   "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/";
 
 var historical = async (keys, redis) => {
-  let casesResponse, deathsResponse, recResponse;
+  let casesResponse, deathsResponse;
   try {
-    casesResponse = await axios.get(
-      `${base}time_series_19-covid-Confirmed.csv`
-    );
-    deathsResponse = await axios.get(`${base}time_series_19-covid-Deaths.csv`);
-    recResponse = await axios.get(`${base}time_series_19-covid-Recovered.csv`);
+    casesResponse = await axios.get(`${base}time_series_covid19_confirmed_global.csv`);
+    deathsResponse = await axios.get(`${base}time_series_covid19_deaths_global.csv`);
   } catch (err) {
     console.log(err);
     return null;
@@ -28,31 +25,22 @@ var historical = async (keys, redis) => {
     output: "csv"
   }).fromString(deathsResponse.data);
 
-  const recParsed = await csv({
-    noheader: true,
-    output: "csv"
-  }).fromString(recResponse.data);
-
   // to store parsed data
   const result = [];
+  // dates key for timeline
   const timelineKey = parsedCases[0].splice(4);
-  // parsedCases.pop()
-  // parsedDeaths.pop()
-  // recParsed.pop()
 
+  // loop over all country entries
   for (let b = 0; b < parsedDeaths.length; ) {
     const timeline = {
       cases: {},
       deaths: {},
-      recovered: {}
     };
     const c = parsedCases[b].splice(4);
-    const r = recParsed[b].splice(4);
     const d = parsedDeaths[b].splice(4);
     for (let i = 0; i < c.length; i++) {
-      timeline.cases[timelineKey[i]] = c[i];
-      timeline.deaths[timelineKey[i]] = d[i];
-      timeline.recovered[timelineKey[i]] = r[i];
+      timeline.cases[timelineKey[i]] = parseInt(c[i]);
+      timeline.deaths[timelineKey[i]] = parseInt(d[i]);
     }
     result.push({
       country: countryMap.standardizeCountryName(parsedCases[b][1].toLowerCase()),

--- a/scraper.js
+++ b/scraper.js
@@ -3,5 +3,5 @@ module.exports = {
     getCountries: require('./funcs/getCountries'),
     getStates: require('./funcs/getStates'),
     jhuLocations: require('./funcs/jhuLocations'),
-    historical: require('./funcs/historical')
+    historical: require('./funcs/historical'),
 }

--- a/server.js
+++ b/server.js
@@ -24,6 +24,7 @@ const execAll = () => {
     scraper.getStates(keys, redis);
     scraper.jhuLocations(keys, redis);
     scraper.historical.historical(keys, redis);
+    scraper.historical.historical_v2(keys, redis);
 };
 execAll()
 setInterval(execAll, config.interval);
@@ -58,6 +59,11 @@ app.get("/jhucsse/", async function (req, res) {
 
 app.get("/historical/", async function (req, res) {
   let data = JSON.parse(await redis.get(keys.historical))
+  res.send(data);
+});
+
+app.get("/historical_v2/", async function (req, res) {
+  let data = JSON.parse(await redis.get(keys.historical_v2))
   res.send(data);
 });
 

--- a/server.js
+++ b/server.js
@@ -62,11 +62,6 @@ app.get("/historical/", async function (req, res) {
   res.send(data);
 });
 
-app.get("/historical_v2/", async function (req, res) {
-  let data = JSON.parse(await redis.get(keys.historical_v2))
-  res.send(data);
-});
-
 app.get("/historical/:country", async function (req, res) {
   let data = JSON.parse(await redis.get(keys.historical));
   const countryData = await scraper.historical.getHistoricalCountryData(data, req.params.country.toLowerCase(), redis, keys.states);
@@ -91,6 +86,20 @@ app.get("/countries/:country", async function (req, res) {
   }
   res.send(country);
 });
+
+// V2 ROUTES
+app.get("/v2/historical/", async function (req, res) {
+  let data = JSON.parse(await redis.get(keys.historical_v2))
+  res.send(data);
+});
+
+app.get("/v2/historical/:country", async function (req, res) {
+  let data = JSON.parse(await redis.get(keys.historical_v2));
+  const countryData = await scraper.historical.getHistoricalCountryData_v2(data, req.params.country.toLowerCase());
+  res.send(countryData);
+});
+
+
 app.get("/invite/", async function (req, res) {
   res.redirect("https://discordapp.com/oauth2/authorize?client_id=685268214435020809&scope=bot&permissions=537250880")
 });


### PR DESCRIPTION
**Please read this** 
# What changed
1. We now have `/v2/historical/` and `/v2/historical/countryName` endpoints, so as to allow users time to switch over from the current ones
2. Only giving cases and deaths, no recovered data
3. All numbers returned from API are integers, no strings
4. No historical data on US states 😢 
5. `/v2/historical/countryName` field used to be `standardizedCountryName` now it is just `country`
6. Updated Readme for JHU data source

# What needs to be changed still
**Whoever is merging this needs to update config.json with these keys:**
```json
"keys": {
    "all": "covidapi:all",
    "countries": "covidapi:countries",
    "states": "covidapi:states",
    "jhu": "covidapi:jhu",
    "historical": "covidapi:historical",
    "historical_v2": "covidapi:historical_v2"
  },
```

I tested this all locally, everything works as expected but if you want to test go ahead