### PR TITLE
/v2/jhucsse endpoint

### DIFF
--- a/funcs/jhuLocations.js
+++ b/funcs/jhuLocations.js
@@ -58,4 +58,90 @@ var jhudata = async (keys, redis) => {
   console.log(`Updated JHU CSSE: ${result.length} locations`);
 };
 
-module.exports = jhudata;
+var jhudata_v2 = async (keys, redis) => {
+  let response;
+  const date = new Date();
+  try {
+    response = await axios.get(
+      `${base}0${date.getMonth() +
+        1}-${date.getDate()}-${date.getFullYear()}.csv`
+    );
+    console.log(
+      `USING 0${date.getMonth() + 1}-${date.getDate() -
+        1}-${date.getFullYear()}.csv CSSEGISandData`
+    );
+  } catch (err) {
+    response = await axios.get(
+      `${base}0${date.getMonth() + 1}-${date.getDate() -
+        1}-${date.getFullYear()}.csv`
+    );
+    console.log(
+      `USING 0${date.getMonth() + 1}-${date.getDate() -
+        1}-${date.getFullYear()}.csv CSSEGISandData`
+    );
+  }
+
+  const parsed = await csv({
+    noheader: true,
+    output: "csv"
+  }).fromString(response.data);
+
+  // to store parsed data
+  const result = [];
+  const statesResult = {};
+
+  for (const loc of parsed.splice(1)) {
+    // city exists only for US entries
+    if (loc[1] != "") {
+      if (statesResult[loc[2]]) {
+        // sum
+        statesResult[loc[2]].stats.confirmed += parseInt(loc[7]);
+        statesResult[loc[2]].stats.deaths += parseInt(loc[8]);
+        statesResult[loc[2]].stats.recovered += parseInt(loc[9]);
+      }
+      else {
+        // initialize
+        statesResult[loc[2]] = {
+          country: loc[3],
+          province: loc[2] === "" ? null : loc[2],
+          updatedAt: loc[4],
+          stats: {
+            confirmed: parseInt(loc[7]),
+            deaths: parseInt(loc[8]),
+            recovered: parseInt(loc[9])
+          },
+          coordinates: {
+            latitude: loc[5],
+            longitude: loc[6]
+          }
+        }
+      }
+    }
+    else {
+      result.push({
+        country: loc[3],
+        province: loc[2] === "" ? null : loc[2],
+        updatedAt: loc[4],
+        stats: {
+          confirmed: parseInt(loc[7]),
+          deaths: parseInt(loc[8]),
+          recovered: parseInt(loc[9])
+        },
+        coordinates: {
+          latitude: loc[5],
+          longitude: loc[6]
+        }
+      });
+    }
+  }
+  // add US entries
+  Object.keys(statesResult).map((state, index) => result.push(statesResult[state]));
+  const string = JSON.stringify(result);
+  redis.set(keys.jhu_v2, string);
+  console.log(`Updated JHU CSSE: ${result.length} locations`);
+};
+
+module.exports = {
+  jhudata,
+  jhudata_v2
+};

--- a/server.js
+++ b/server.js
@@ -22,7 +22,8 @@ const execAll = () => {
     scraper.getCountries(keys, redis);
     scraper.getAll(keys, redis);
     scraper.getStates(keys, redis);
-    scraper.jhuLocations(keys, redis);
+    scraper.jhuLocations.jhudata(keys, redis);
+    scraper.jhuLocations.jhudata_v2(keys, redis);
     scraper.historical.historical(keys, redis);
     scraper.historical.historical_v2(keys, redis);
 };
@@ -97,6 +98,11 @@ app.get("/v2/historical/:country", async function (req, res) {
   let data = JSON.parse(await redis.get(keys.historical_v2));
   const countryData = await scraper.historical.getHistoricalCountryData_v2(data, req.params.country.toLowerCase());
   res.send(countryData);
+});
+
+app.get("/v2/jhucsse/", async function (req, res) {
+  let data = JSON.parse(await redis.get(keys.jhu_v2))
+  res.send(data);
 });
 
 


### PR DESCRIPTION
Removes all city fields from response, and unionizes US states to one entry instead of like 30 different ones with cities.

# PLEASE ADD THIS KEY TO `CONFIG.JS` MERGE
```json
"jhu_v2": "covidapi:jhu_v2"
```