### PR TITLE
🐛 FIX: Grammar & Lingo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ https://corona.lmao.ninja/
 
 ## Loading and using our NPM Package
 
-We suggest you load the module via `require`, pending the stabalizing of es modules in node:
+We suggest you load the module via `require`, considering ES modules in Node.js are not yet stable.
 
 ```js
 const covid = require('novelcovid');
 ```
 
-# Documentation
+## Documentation
 
 To actually use the data, you will need an [async/await](https://javascript.info/async-await).
 


### PR DESCRIPTION
This PR removes a typo `stabalizing` and rephrases that in the readme. 

I also fixed the docs heading because there should be at the most one `h1` tag on a page so Google can prioritize that for organic search.