### PR TITLE
Improve the parsing of the table data from WorldMeteres

### DIFF
--- a/funcs/getCountries.js
+++ b/funcs/getCountries.js
@@ -123,13 +123,17 @@ var getcountries = async (keys, redis) => {
         // get total cases per one million population
         if (i % totalColumns === casesPerOneMillionColIndex) {
             let casesPerOneMillion = cell.children.length != 0 ? cell.children[0].data : "";
-            result[result.length - 1].casesPerOneMillion = parseFloat(casesPerOneMillion);
+            result[result.length - 1].casesPerOneMillion = parseFloat(
+                casesPerOneMillion.trim().replace(/,/g, "") || "0"
+            );
         }
 
         // get total deaths per one million population
         if (i % totalColumns === deathsPerOneMillionColIndex) {
             let deathsPerOneMillion = cell.children.length != 0 ? cell.children[0].data : "";
-            result[result.length - 1].deathsPerOneMillion = parseFloat(deathsPerOneMillion);
+            result[result.length - 1].deathsPerOneMillion = parseFloat(
+                deathsPerOneMillion.trim().replace(/,/g, "") || "0"
+            );
         }
     }
 


### PR DESCRIPTION
Update `casesPerOneMillion` and `deathsPerOneMillion` to handle comma grouped values and empty values in the WorldMeteres table.

Fixes the issue where values over 1000 are shown just as the first digit.
Fixes issue where value comes back as `null` if the column was empty. 0 seems like better value than a null + consistency with the other int columns of the API