### PR TITLE
WorldOMeter Format Change Fix

### DIFF
--- a/funcs/getCountries.js
+++ b/funcs/getCountries.js
@@ -22,7 +22,7 @@ var getcountries = async (keys, redis) => {
         .children("tr")
         .children("td");
     // NOTE: this will change when table format change in website
-    const totalColumns = 10;
+    const totalColumns = 11;
     const countryColIndex = 0;
     const casesColIndex = 1;
     const todayCasesColIndex = 2;


### PR DESCRIPTION
A new recent column added  in countries tab broke the parser. This PR fixes it and allows countries to update again.