### PR TITLE
[WPI][RFC] Adds United States' county data

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -9,7 +9,9 @@
     "countries": "covidapi:countries",
     "states": "covidapi:states",
     "jhu": "covidapi:jhu",
-    "historical": "covidapi:historical"
+    "historical": "covidapi:historical",
+    "counties": "covidapi:counties",
+    "historicalCounties": "covidapi:historicalCounties"
   },
   "port": 3000,
   "interval": 600000


### PR DESCRIPTION
It could be useful to have county data within the United States for analytics and such. The New York Times recently published their dataset on Covid-19, which includes historical county data. They said it should be updated regularly. This commit adds county data and historical county data calls to the api. These api calls are not formatted like many others because of the way the data is processed; this could easily be changed.

Sorry if the programming style is a little weird (I don't program js), but if you like the idea there are a couple of things I should to do before it should be committed: write docs, and look into getting data from the New York Times website directly because they have a [table](https://www.nytimes.com/interactive/2020/us/coronavirus-us-cases.html?auth=login-google#g-cases-by-county) with all the counties, which updates more frequently (I didn't realize until after I wrote it). Please tell me what you think.

FYI my discord is josephg#8363