### PR TITLE
Add counties to v2/jhucsse endpoint

### DIFF
--- a/funcs/jhuLocations.js
+++ b/funcs/jhuLocations.js
@@ -38,8 +38,8 @@ const jhudata = async (keys, redis) => {
 	parsed.splice(1).forEach((loc) => {
 		result.push({
 			country: loc[3],
-			province: loc[2] === '' ? null : loc[2],
-			city: loc[1] === '' ? null : loc[1],
+			province: loc[2] || null,
+			city: loc[1] || null,
 			updatedAt: loc[4],
 			stats: {
 				confirmed: loc[7],
@@ -94,8 +94,8 @@ const jhudataV2 = async (keys, redis) => {
 	parsed.splice(1).forEach((loc) => {
 		result.push({
 			country: loc[3],
-			province: loc[2] === '' ? null : loc[2],
-			county: loc[1] === '' ? null : loc[1],
+			province: loc[2] || null,
+			county: loc[1] || null,
 			updatedAt: loc[4],
 			stats: {
 				confirmed: parseInt(loc[7]),
@@ -125,7 +125,7 @@ const generalizedJhudataV2 = (data) => {
 	data.forEach((loc) => {
 		const defaultData = {
 			country: loc.country,
-			province: loc.province === '' ? null : loc.province,
+			province: loc.province || null,
 			updatedAt: loc.updatedAt,
 			stats: {
 				confirmed: loc.stats.confirmed,

--- a/funcs/jhuLocations.js
+++ b/funcs/jhuLocations.js
@@ -143,8 +143,19 @@ const generalizedJhudataV2 = (data) => {
 	return result;
 };
 
+/**
+ * Filters JHU data to all counties or specific county names if specified
+ * @param 	{Object} 	data	All JHU data retrieved from redis store
+ * @param 	{string} 	county	Name of a county in the USA
+ * @returns {Array}				All data with county names the same as input, or all county data if no county param
+ */
+const getCountyJhuDataV2 = (data, county = null) =>
+	county ? data.filter((loc) => loc.county !== null && loc.county.toLowerCase() === county)
+		: data.filter((loc) => loc.county !== null);
+
 module.exports = {
 	jhudata,
 	jhudataV2,
-	generalizedJhudataV2
+	generalizedJhudataV2,
+	getCountyJhuDataV2
 };

--- a/funcs/jhuLocations.js
+++ b/funcs/jhuLocations.js
@@ -85,10 +85,7 @@ const jhudataV2 = async (keys, redis) => {
 		output: 'csv'
 	}).fromString(response.data);
 
-	// to store parsed data
 	const result = [];
-	const statesResult = {};
-
 	parsed.splice(1).forEach((loc) => {
 		result.push({
 			country: loc[3],
@@ -105,55 +102,66 @@ const jhudataV2 = async (keys, redis) => {
 				longitude: loc[6]
 			}
 		});
-		// city exists only for US entries
-		// if (loc[1] !== '') {
-		// 	if (statesResult[loc[2]]) {
-		// 		// sum
-		// 		statesResult[loc[2]].stats.confirmed += parseInt(loc[7]);
-		// 		statesResult[loc[2]].stats.deaths += parseInt(loc[8]);
-		// 		statesResult[loc[2]].stats.recovered += parseInt(loc[9]);
-		// 	} else {
-		// 		// initialize
-		// 		statesResult[loc[2]] = {
-		// 			country: loc[3],
-		// 			province: loc[2] === '' ? null : loc[2],
-		// 			updatedAt: loc[4],
-		// 			stats: {
-		// 				confirmed: parseInt(loc[7]),
-		// 				deaths: parseInt(loc[8]),
-		// 				recovered: parseInt(loc[9])
-		// 			},
-		// 			coordinates: {
-		// 				latitude: loc[5],
-		// 				longitude: loc[6]
-		// 			}
-		// 		};
-		// 	}
-		// } else {
-		// 	result.push({
-		// 		country: loc[3],
-		// 		province: loc[2] === '' ? null : loc[2],
-		// 		updatedAt: loc[4],
-		// 		stats: {
-		// 			confirmed: parseInt(loc[7]),
-		// 			deaths: parseInt(loc[8]),
-		// 			recovered: parseInt(loc[9])
-		// 		},
-		// 		coordinates: {
-		// 			latitude: loc[5],
-		// 			longitude: loc[6]
-		// 		}
-		// 	});
-		// }
 	});
-	// add US entries
-	// Object.keys(statesResult).map((state) => result.push(statesResult[state]));
 	const string = JSON.stringify(result);
 	redis.set(keys.jhu_v2, string);
 	console.log(`Updated JHU CSSE: ${result.length} locations`);
 };
 
+const generalizedJhudataV2 = (data) => {
+	const result = [];
+	const statesResult = {};
+
+	console.log(data[0].stats);
+
+	data.forEach((loc) => {
+		// city exists only for US entries
+		if (loc.county !== '') {
+			if (statesResult[loc.province]) {
+				// sum
+				statesResult[loc.province].stats.confirmed += parseInt(loc.stats.confirmed);
+				statesResult[loc.province].stats.deaths += parseInt(loc.deaths);
+				statesResult[loc.province].stats.recovered += parseInt(loc.recovered);
+			} else {
+				// initialize
+				statesResult[loc.province] = {
+					country: loc.country,
+					province: loc.province === '' ? null : loc.province,
+					updatedAt: loc.updatedAt,
+					stats: {
+						confirmed: parseInt(loc.stats.confirmed),
+						deaths: parseInt(loc.stats.deaths),
+						recovered: parseInt(loc.stats.recovered)
+					},
+					coordinates: {
+						latitude: loc.coordinates.latitude,
+						longitude: loc.coordinates.longitude
+					}
+				};
+			}
+		} else {
+			result.push({
+				country: loc[3],
+				province: loc[2] === '' ? null : loc[2],
+				updatedAt: loc[4],
+				stats: {
+					confirmed: parseInt(loc[7]),
+					deaths: parseInt(loc[8]),
+					recovered: parseInt(loc[9])
+				},
+				coordinates: {
+					latitude: loc[5],
+					longitude: loc[6]
+				}
+			});
+		}
+	});
+	Object.keys(statesResult).map((state) => result.push(statesResult[state]));
+	return result;
+};
+
 module.exports = {
 	jhudata,
-	jhudataV2
+	jhudataV2,
+	generalizedJhudataV2
 };

--- a/funcs/jhuLocations.js
+++ b/funcs/jhuLocations.js
@@ -90,49 +90,64 @@ const jhudataV2 = async (keys, redis) => {
 	const statesResult = {};
 
 	parsed.splice(1).forEach((loc) => {
-	// city exists only for US entries
-		if (loc[1] !== '') {
-			if (statesResult[loc[2]]) {
-				// sum
-				statesResult[loc[2]].stats.confirmed += parseInt(loc[7]);
-				statesResult[loc[2]].stats.deaths += parseInt(loc[8]);
-				statesResult[loc[2]].stats.recovered += parseInt(loc[9]);
-			} else {
-				// initialize
-				statesResult[loc[2]] = {
-					country: loc[3],
-					province: loc[2] === '' ? null : loc[2],
-					updatedAt: loc[4],
-					stats: {
-						confirmed: parseInt(loc[7]),
-						deaths: parseInt(loc[8]),
-						recovered: parseInt(loc[9])
-					},
-					coordinates: {
-						latitude: loc[5],
-						longitude: loc[6]
-					}
-				};
+		result.push({
+			country: loc[3],
+			province: loc[2] === '' ? null : loc[2],
+			county: loc[1] === '' ? null : loc[1],
+			updatedAt: loc[4],
+			stats: {
+				confirmed: parseInt(loc[7]),
+				deaths: parseInt(loc[8]),
+				recovered: parseInt(loc[9])
+			},
+			coordinates: {
+				latitude: loc[5],
+				longitude: loc[6]
 			}
-		} else {
-			result.push({
-				country: loc[3],
-				province: loc[2] === '' ? null : loc[2],
-				updatedAt: loc[4],
-				stats: {
-					confirmed: parseInt(loc[7]),
-					deaths: parseInt(loc[8]),
-					recovered: parseInt(loc[9])
-				},
-				coordinates: {
-					latitude: loc[5],
-					longitude: loc[6]
-				}
-			});
-		}
+		});
+		// city exists only for US entries
+		// if (loc[1] !== '') {
+		// 	if (statesResult[loc[2]]) {
+		// 		// sum
+		// 		statesResult[loc[2]].stats.confirmed += parseInt(loc[7]);
+		// 		statesResult[loc[2]].stats.deaths += parseInt(loc[8]);
+		// 		statesResult[loc[2]].stats.recovered += parseInt(loc[9]);
+		// 	} else {
+		// 		// initialize
+		// 		statesResult[loc[2]] = {
+		// 			country: loc[3],
+		// 			province: loc[2] === '' ? null : loc[2],
+		// 			updatedAt: loc[4],
+		// 			stats: {
+		// 				confirmed: parseInt(loc[7]),
+		// 				deaths: parseInt(loc[8]),
+		// 				recovered: parseInt(loc[9])
+		// 			},
+		// 			coordinates: {
+		// 				latitude: loc[5],
+		// 				longitude: loc[6]
+		// 			}
+		// 		};
+		// 	}
+		// } else {
+		// 	result.push({
+		// 		country: loc[3],
+		// 		province: loc[2] === '' ? null : loc[2],
+		// 		updatedAt: loc[4],
+		// 		stats: {
+		// 			confirmed: parseInt(loc[7]),
+		// 			deaths: parseInt(loc[8]),
+		// 			recovered: parseInt(loc[9])
+		// 		},
+		// 		coordinates: {
+		// 			latitude: loc[5],
+		// 			longitude: loc[6]
+		// 		}
+		// 	});
+		// }
 	});
 	// add US entries
-	Object.keys(statesResult).map((state) => result.push(statesResult[state]));
+	// Object.keys(statesResult).map((state) => result.push(statesResult[state]));
 	const string = JSON.stringify(result);
 	redis.set(keys.jhu_v2, string);
 	console.log(`Updated JHU CSSE: ${result.length} locations`);

--- a/funcs/jhuLocations.js
+++ b/funcs/jhuLocations.js
@@ -112,48 +112,31 @@ const generalizedJhudataV2 = (data) => {
 	const result = [];
 	const statesResult = {};
 
-	console.log(data[0].stats);
-
 	data.forEach((loc) => {
+		const defaultData = {
+			country: loc.country,
+			province: loc.province === '' ? null : loc.province,
+			updatedAt: loc.updatedAt,
+			stats: {
+				confirmed: loc.stats.confirmed,
+				deaths: loc.stats.deaths,
+				recovered: loc.stats.recovered
+			},
+			coordinates: {
+				latitude: loc.coordinates.latitude,
+				longitude: loc.coordinates.longitude
+			}
+		};
 		// city exists only for US entries
-		if (loc.county !== '') {
+		if (loc.county !== null) {
 			if (statesResult[loc.province]) {
 				// sum
-				statesResult[loc.province].stats.confirmed += parseInt(loc.stats.confirmed);
-				statesResult[loc.province].stats.deaths += parseInt(loc.deaths);
-				statesResult[loc.province].stats.recovered += parseInt(loc.recovered);
-			} else {
-				// initialize
-				statesResult[loc.province] = {
-					country: loc.country,
-					province: loc.province === '' ? null : loc.province,
-					updatedAt: loc.updatedAt,
-					stats: {
-						confirmed: parseInt(loc.stats.confirmed),
-						deaths: parseInt(loc.stats.deaths),
-						recovered: parseInt(loc.stats.recovered)
-					},
-					coordinates: {
-						latitude: loc.coordinates.latitude,
-						longitude: loc.coordinates.longitude
-					}
-				};
-			}
+				statesResult[loc.province].stats.confirmed += loc.stats.confirmed;
+				statesResult[loc.province].stats.deaths += loc.stats.deaths;
+				statesResult[loc.province].stats.recovered += loc.stats.recovered;
+			} else { statesResult[loc.province] = defaultData; }
 		} else {
-			result.push({
-				country: loc[3],
-				province: loc[2] === '' ? null : loc[2],
-				updatedAt: loc[4],
-				stats: {
-					confirmed: parseInt(loc[7]),
-					deaths: parseInt(loc[8]),
-					recovered: parseInt(loc[9])
-				},
-				coordinates: {
-					latitude: loc[5],
-					longitude: loc[6]
-				}
-			});
+			result.push(defaultData);
 		}
 	});
 	Object.keys(statesResult).map((state) => result.push(statesResult[state]));

--- a/funcs/jhuLocations.js
+++ b/funcs/jhuLocations.js
@@ -57,6 +57,11 @@ const jhudata = async (keys, redis) => {
 	console.log(`Updated JHU CSSE: ${result.length} locations`);
 };
 
+/**
+ * Sets redis store full of today's JHU data scraped from their hosted CSV
+ * @param {string} 	keys 	JHU data redis key
+ * @param {Object} 	redis 	Redis instance
+ */
 const jhudataV2 = async (keys, redis) => {
 	let response;
 	const date = new Date();
@@ -108,6 +113,11 @@ const jhudataV2 = async (keys, redis) => {
 	console.log(`Updated JHU CSSE: ${result.length} locations`);
 };
 
+/**
+ * Returns JHU data with US states summed over counties
+ * @param 	{Object} 	data 	All JHU data retrieved from redis store
+ * @returns {Array} 			All data objects from JHU set for today with states summed over counties
+ */
 const generalizedJhudataV2 = (data) => {
 	const result = [];
 	const statesResult = {};
@@ -147,7 +157,7 @@ const generalizedJhudataV2 = (data) => {
  * Filters JHU data to all counties or specific county names if specified
  * @param 	{Object} 	data	All JHU data retrieved from redis store
  * @param 	{string} 	county	Name of a county in the USA
- * @returns {Array}				All data with county names the same as input, or all county data if no county param
+ * @returns {Array}				All data from today with county names the same as input, or all county data if no county param
  */
 const getCountyJhuDataV2 = (data, county = null) =>
 	county ? data.filter((loc) => loc.county !== null && loc.county.toLowerCase() === county)

--- a/server.js
+++ b/server.js
@@ -137,7 +137,8 @@ app.get('/v2/historical/:query/:province?', async (req, res) => {
 
 app.get('/v2/jhucsse', async (req, res) => {
 	const data = JSON.parse(await redis.get(keys.jhu_v2));
-	res.send(data);
+	const generalizedData = scraper.jhuLocations.generalizedJhudataV2(data);
+	res.send(generalizedData);
 });
 
 // deprecated

--- a/server.js
+++ b/server.js
@@ -141,6 +141,17 @@ app.get('/v2/jhucsse', async (req, res) => {
 	res.send(generalizedData);
 });
 
+app.get('/v2/jhucsse/counties/:county?', async (req, res) => {
+	const { county } = req.params;
+	const data = JSON.parse(await redis.get(keys.jhu_v2));
+	const countyData = scraper.jhuLocations.getCountyJhuDataV2(data, county && county.toLowerCase());
+	if (countyData.length > 0) {
+		res.send(countyData);
+	} else {
+		res.status(404).send({ message: 'County not found' });
+	}
+});
+
 // deprecated
 app.get('/historical', async (req, res) => {
 	res.send({ message: 'Deprecated, use /v2/historical' });


### PR DESCRIPTION
# What does this PR do?
generally closes #289 
1. Add `v2/jhucsse/counties` endpoint for getting data on every county in the USA
2. Add `v2/jhucsse/counties/county` endpoint for getting data on specific county names.

I have tested the PR locally, but **please** test all `v2/jhucsse` functionality for this PR locally before I merge it, I want some feedback and to make sure the original endpoint is still fine.

# How to test?
1. git remote add pr-305 https://github.com/ebwinters/API
2. git fetch pr-305
3. git checkout -b pr-305-master pr-305/master
4. start a redis server with `redis-server`
5. start node server with `node server.js`
6. go to your local host

![](https://media2.giphy.com/media/hPrt0zRTMAVaugcgPf/giphy.gif?cid=ecf05e47e59c6ae3091327f4d67a6ffac9ca6a9a01d55215&rid=giphy.gif)