### PR TITLE
Query multiple countries for historical data

### DIFF
--- a/server.js
+++ b/server.js
@@ -126,14 +126,24 @@ app.get('/v2/historical/:query/:province?', async (req, res) => {
 	const data = JSON.parse(await redis.get(keys.historical_v2));
 	const { query, province } = req.params;
 	const countries = query.split(',');
-	const provinces = province && province.split(',');
+	const provinces = (province && province.split(',')) || [];
 	let countryData;
-	if (countries.length > 0) {
-		countryData = countries.map((country, i) =>
+	// multiple countries no provinces allowed
+	if (countries.length > 1) {
+		countryData = countries.map((country) =>
 			scraper.historical.getHistoricalCountryDataV2(
 				data,
 				country.toLowerCase(),
-				provinces && provinces[i] && provinces[i].toLowerCase()
+				null
+			) || { err: 'Country not found or doesn\'t have any historical data' }
+		);
+	} else if (provinces.length > 0) {
+		// provinces for one country
+		countryData = provinces.map((prov) =>
+			scraper.historical.getHistoricalCountryDataV2(
+				data,
+				countries[0].toLowerCase(),
+				prov.toLowerCase().trim()
 			) || { err: 'Country not found or doesn\'t have any historical data' }
 		);
 	} else {
@@ -144,7 +154,7 @@ app.get('/v2/historical/:query/:province?', async (req, res) => {
 		);
 	}
 	if (countryData) {
-		res.send(countryData);
+		res.send(countryData.length === 1 ? countryData[0] : countryData);
 	} else {
 		res.status(404).send({ message: 'Country not found or doesn\'t have any historical data' });
 	}

--- a/server.js
+++ b/server.js
@@ -123,11 +123,24 @@ app.get('/v2/historical/all', async (req, res) => {
 app.get('/v2/historical/:query/:province?', async (req, res) => {
 	const data = JSON.parse(await redis.get(keys.historical_v2));
 	const { query, province } = req.params;
-	const countryData = await scraper.historical.getHistoricalCountryDataV2(
-		data,
-		query.toLowerCase(),
-		province && province.toLowerCase()
-	);
+	const countries = query.split(',');
+	const provinces = province && province.split(',');
+	let countryData;
+	if (countries.length > 0) {
+		countryData = countries.map((country, i) =>
+			scraper.historical.getHistoricalCountryDataV2(
+				data,
+				country.toLowerCase(),
+				provinces && provinces[i] && provinces[i].toLowerCase()
+			)
+		);
+	} else {
+		countryData = scraper.historical.getHistoricalCountryDataV2(
+			data,
+			query.toLowerCase(),
+			province && province.toLowerCase()
+		);
+	}
 	if (countryData) {
 		res.send(countryData);
 	} else {

--- a/server.js
+++ b/server.js
@@ -132,7 +132,7 @@ app.get('/v2/historical/:query/:province?', async (req, res) => {
 				data,
 				country.toLowerCase(),
 				provinces && provinces[i] && provinces[i].toLowerCase()
-			)
+			) || { err: 'Country not found or doesn\'t have any historical data' }
 		);
 	} else {
 		countryData = scraper.historical.getHistoricalCountryDataV2(


### PR DESCRIPTION
This closes #303 – more specifically, it allows multiple countries to be accessed at the `/v2/historical/query` endpoint, where query can now be a comma-separated list of countries as described in that issue.

It also continues to support provinces in this format: 

`https://corona.lmao.ninja/v2/historical/country1,country2,country3/province1,province2`

where provinces are listed in the same order as the countries (any countries that you don't want provinces for can be listed at the end of the country list, so `country3` in the above list would be returned in full as normal).

I wasn't sure if there was any specific convention to be followed here as I haven't contributed to this project before – let me know if you have any ideas for presenting this data differently.

I'd have updated the docs as well, but they don't seem to be part of this repo.