### PR TITLE
Add mainland province for null field historical

### DIFF
--- a/funcs/historical.js
+++ b/funcs/historical.js
@@ -125,7 +125,7 @@ const getHistoricalCountryDataV2 = (data, query, province = null) => {
 	const countryData = data.filter(item => {
 		if (item.countryInfo._id === null) return false;
 		if (province) {
-			return item.province && item.province === province
+			return (item.province === province || (item.province === null && province === 'mainland'))
 				&& (stringUtils.wordsStandardize(item.country).includes(standardizedCountryName)
 					|| item.countryInfo.iso2 === countryInfo.iso2
 					|| item.countryInfo.iso3 === countryInfo.iso3
@@ -142,7 +142,7 @@ const getHistoricalCountryDataV2 = (data, query, province = null) => {
 	const timeline = { cases: {}, deaths: {}, recovered: {} };
 	const provinces = [];
 	countryData.forEach((_, index) => {
-		if (countryData[index].province) provinces.push(countryData[index].province);
+		countryData[index].province ? provinces.push(countryData[index].province) : provinces.push('mainland');
 		// loop cases, deaths for each province
 		Object.keys(countryData[index].timeline).forEach((specifier) => {
 			Object.keys(countryData[index].timeline[specifier]).forEach((date) => {


### PR DESCRIPTION
fix #350 

Basically if you want to view data for a mainland country like the Netherlands, you can do so by accessing it as a province, `/netherlands/mainland`