### PR TITLE
Initial changes to run unit tests in docker.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@ FROM node:13
 RUN mkdir -p /home/container
 WORKDIR /home/container
 
-COPY . /home/container
+# we should only re-run npm install if package.json specifically has changed. use docker build cache otherwise
+COPY ./package.json /home/container/package.json
 RUN npm i
+
+# copy everything else over
+COPY . /home/container
 
 CMD [ "node", "server.js" ]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,4 @@
+version: '3.7'
+services:
+  app:
+    command: ["npm", "run", "test"]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint": "eslint '**/*.js' --ignore-pattern node_modules/",
     "lint:fix": "eslint ./**/*.js --fix --ignore-pattern node_modules/",
     "lint:win32": "eslint ./**/*.js --ignore-pattern node_modules/",
-    "test": "mocha ./tests --exit  --timeout 50000"
+    "test": "mocha ./tests --exit  --timeout 50000",
+    "docker-test": "docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit --build"
   },
   "dependencies": {
     "axios": "^0.19.2",


### PR DESCRIPTION
Made some quality of life changes in Dockerfile so that it can reuse installed packages even if you make a code change.
Added .dockerignore to ensure that host machine node_modules do not squash installed node_modules inside the container.
Added `docker-test` command to package.json.
Added `docker-compose.test.yml` to change the command run in the `covid-api-app` container.

Once you've set up your local environment to successfully run the app in docker, you should be able to just run `npm run docker-test`.

It will build the container on every invocation, but docker caching should make the rebuild quick. Note that you can read the exit code of the command, and it will be 0 if all of the tests passed or 1 if there were any failures.