### PR TITLE
[Proposal] Dockerize scraper

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  file: [ './tests/mochaGlobalSetup.js' ]
+};

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@ FROM node:13
 RUN mkdir -p /home/container
 WORKDIR /home/container
 
-COPY . /home/container
+# we should only re-run npm install if package.json specifically has changed. use docker build cache otherwise
+COPY ./package.json /home/container/package.json
 RUN npm i
+
+# copy everything else over
+COPY . /home/container
 
 CMD [ "node", "server.js" ]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,25 @@
+version: '3.7'
+services:
+  redis:
+    container_name: covid-api-redis
+    volumes:
+      - redis-data:/data
+
+  scraper:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: covid-api-app-scraper
+    networks:
+      - redis-net
+    depends_on:
+      - redis
+    command: ["node", "scrape.js"]
+
+  app:
+    ports:
+      - 30001:3000
+    container_name: covid-api-app
+
+volumes:
+  redis-data:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,4 @@
+version: '3.7'
+services:
+  app:
+    command: ["npm", "run", "test"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,13 @@
 version: '3.7'
 services:
+  redis:
+    container_name: covid-api-redis-test
+    volumes:
+      - redis-data-test:/data
+
   app:
     command: ["npm", "run", "test"]
+    container_name: covid-api-app-test
+
+volumes:
+  redis-data-test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,20 +4,15 @@ services:
     image: redis:4.0.5-alpine
     command: ["redis-server", "--appendonly", "yes", "--requirepass", "yourpassword"]
     hostname: redis
-    container_name: covid-api-redis
     networks:
       - redis-net
-    volumes:
-      - redis-data:/data
     ports:
       - 6379
+
   app:
     build:
       context: .
       dockerfile: Dockerfile
-    ports:
-      - 30001:3000
-    container_name: covid-api-app
     networks:
       - redis-net
     depends_on:
@@ -25,6 +20,3 @@ services:
 
 networks:
   redis-net:
-
-volumes:
-  redis-data:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint": "eslint '**/*.js' --ignore-pattern node_modules/",
     "lint:fix": "eslint ./**/*.js --fix --ignore-pattern node_modules/",
     "lint:win32": "eslint ./**/*.js --ignore-pattern node_modules/",
-    "test": "mocha ./tests --exit  --timeout 50000"
+    "test": "mocha ./tests --exit  --timeout 50000",
+    "docker-test": "docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit --build"
   },
   "dependencies": {
     "axios": "^0.19.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint:fix": "eslint ./**/*.js --fix --ignore-pattern node_modules/",
     "lint:win32": "eslint ./**/*.js --ignore-pattern node_modules/",
     "test": "mocha ./tests --exit  --timeout 50000",
+    "docker-start": "docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --build",
     "docker-test": "docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit --build"
   },
   "dependencies": {

--- a/routes/instances.js
+++ b/routes/instances.js
@@ -30,6 +30,15 @@ module.exports = {
 		getWorldometerPage,
 		getStates,
 		jhuLocations,
-		historical
+		historical,
+		executeScrapeJob: async () => {
+			await Promise.all([
+				getWorldometerPage(keys, redis),
+				getStates(keys, redis),
+				jhuLocations.jhudataV2(keys, redis),
+				historical.historicalV2(keys, redis),
+				historical.getHistoricalUSADataV2(keys, redis)
+			]);
+		}
 	}
 };

--- a/scrape.js
+++ b/scrape.js
@@ -1,0 +1,10 @@
+const { config, scraper: { executeScrapeJob } } = require('./routes/instances');
+
+const logWithDate = (message) => console.log(`[${new Date().toISOString()}]: ${message}`);
+
+logWithDate('Starting initial scrape job...');
+executeScrapeJob().then(() => logWithDate('Initial scrape job finished.'));
+setInterval(() => {
+	logWithDate('Scrape job waking up and executing...');
+	executeScrapeJob().then(() => logWithDate('Finished scrape job.'));
+}, config.interval);

--- a/server.js
+++ b/server.js
@@ -2,21 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const swaggerUi = require('swagger-ui-express');
 const app = express();
-const { redis, config, keys, scraper } = require('./routes/instances');
-
-const execAll = async () => {
-	await Promise.all([
-		scraper.getWorldometerPage(keys, redis),
-		scraper.getStates(keys, redis),
-		scraper.jhuLocations.jhudataV2(keys, redis),
-		scraper.historical.historicalV2(keys, redis),
-		scraper.historical.getHistoricalUSADataV2(keys, redis)
-	]);
-	app.emit('scrapper_finished');
-};
-
-execAll();
-setInterval(execAll, config.interval);
+const { config } = require('./routes/instances');
 
 app.use(cors());
 app.get('/', async (request, response) => response.redirect('https://github.com/novelcovid/api'));

--- a/tests/api_deprecated.spec.js
+++ b/tests/api_deprecated.spec.js
@@ -4,13 +4,6 @@ const app = require('../server');
 const should = chai.should();
 chai.use(chaiHttp);
 
-before(done => {
-    app.on('scrapper_finished', function() {
-        console.log('Scrapper Finished...');
-        done();
-    });
-});
-
 describe('TESTING DEPRECATED METHODS', () => {
     it('Testing /historical', (done) => {
         chai.request(app)

--- a/tests/mochaGlobalSetup.js
+++ b/tests/mochaGlobalSetup.js
@@ -1,0 +1,10 @@
+const { scraper: { executeScrapeJob }, redis } = require('../routes/instances');
+
+// eslint-disable-next-line
+before(async () => {
+	await redis.flushall();
+	console.log('Finished flushing all data from redis.');
+
+	await executeScrapeJob();
+	console.log('Scraping finished.');
+});


### PR DESCRIPTION
Picking up where I left off with dockerizing unit tests.

### GOALS:

1) Split up the scraper job from the web server.
2) Enable docker development flow.

### DESIGN:

We were able to reuse most of the existing code. The main changes were:

- Refactoring the scraper job out of `server.js` and creating a `scraper.js` entrypoint for the scraper.
- Creating a second container for the scraper that uses the `scraper.js` entrypoint. It is able to reuse the `Dockerfile` for the web server container, and also uses a lot of the same configuration in the `docker-compose` files.
- Created a command in `package.json` to both start the production containers and also run the unit tests. Look at `docker-start` and `docker-test`.

### Notes:

I've moved all of the base docker-compose components that are shared between prod and test into `docker-compose.yml`. Using the yml merging feature of `docker-compose`, there are two new docker-compose yml configs for test and prod. The configs use different names for each container in test and prod, as well as the prod config defining the scraper container. The redis containers in test and prod use different volumes so that unit tests do not interact with the main redis store, and vice versa.

The scraper container is not run at all during unit tests. Instead, we've added a `mochaGlobalSetup.js` file, which contains all of the setup we need to run before any mocha tests are run. This is where we run the initial scrape job, but not before flushing the redis instance to ensure that a previous test run is cleaned up before running the current test run.

Note that the docker file seemingly has a redundant copy of `package.json` before copying over all of the contents of the directory. This is intentional, and we are leveraging the caching of docker layers when docker is building images in order to decrease the time between tests runs when code is changed but we have not made any changes to any node dependencies and don't need to re-run `npm i`. Look [here](https://github.com/NovelCOVID/API/pull/510#discussion_r407885729) for more details.

### TODO

We would need to update the readme to reflect the new way of running the app in docker.

Do we want to flush redis in all environments (aka, if someone is developing locally and not in docker)? Potentially, we could set an environment variable that controls this behavior and turn it on in docker, while leaving it off by default otherwise.