### PR TITLE
NYT Integration

### DIFF
--- a/assets/apidocs/swagger_v2.json
+++ b/assets/apidocs/swagger_v2.json
@@ -579,7 +579,7 @@
         "parameters": [
           {
             "name": "state",
-            "in": "query",
+            "in": "path",
             "required": false,
             "description": "The state that you'd like to search for, separated by comma if you want to search for multiple (i.e. 'California, Washington'. Default is full data set",
             "type": "string"
@@ -605,7 +605,7 @@
         "parameters": [
           {
             "name": "county",
-            "in": "query",
+            "in": "path",
             "required": false,
             "description": "The county that you'd like to search for, separated by comma if you want to search for multiple (i.e. 'Alameda, Humboldt'). Default is full data set",
             "type": "string"

--- a/assets/apidocs/swagger_v2.json
+++ b/assets/apidocs/swagger_v2.json
@@ -581,7 +581,7 @@
             "name": "state",
             "in": "query",
             "required": false,
-            "description": "The state that you'd like to search for. Default is full data set",
+            "description": "The state that you'd like to search for, separated by comma if you want to search for multiple (i.e. 'California, Washington'. Default is full data set",
             "type": "string"
           }
         ],
@@ -607,7 +607,7 @@
             "name": "county",
             "in": "query",
             "required": false,
-            "description": "The county that you'd like to search for. Default is full data set",
+            "description": "The county that you'd like to search for, separated by comma if you want to search for multiple (i.e. 'Alameda, Humboldt'). Default is full data set",
             "type": "string"
           }
         ],
@@ -623,7 +623,7 @@
         }
       }
     },
-    "/v2/nyt/nation_wide": {
+    "/v2/nyt/usa": {
       "get": {
         "tags": [
           "NYT"

--- a/assets/apidocs/swagger_v2.json
+++ b/assets/apidocs/swagger_v2.json
@@ -26,6 +26,10 @@
     {
       "name": "JHUCSSE",
       "description": "(Data from Johns Hopkins University)"
+    },
+    {
+      "name": "NYT",
+      "description": "(Data from New York Times)"
     }
   ],
   "consumes": [
@@ -566,6 +570,75 @@
           }
         }
       }
+    },
+    "/v2/nyt/states": {
+      "get": {
+        "tags": [
+          "NYT"
+        ],
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "The state that you'd like to search for. Default is full data set",
+            "type": "string"
+          }
+        ],
+        "summary": "Get State Data",
+        "description": "Return all NYT state data or individual state data if specified. Each entry returned represents data for a given day.",
+        "responses": {
+          "200": {
+            "description": "Status Ok",
+            "schema": {
+              "$ref": "#/definitions/nytStates"
+            }
+          }
+        }
+      }
+    },
+    "/v2/nyt/counties": {
+      "get": {
+        "tags": [
+          "NYT"
+        ],
+        "parameters": [
+          {
+            "name": "county",
+            "in": "query",
+            "required": false,
+            "description": "The county that you'd like to search for. Default is full data set",
+            "type": "string"
+          }
+        ],
+        "summary": "Get County Data",
+        "description": "Return all NYT county data or individual county data if specified. Each entry returned represents data for a given day.",
+        "responses": {
+          "200": {
+            "description": "Status Ok",
+            "schema": {
+              "$ref": "#/definitions/nytCounties"
+            }
+          }
+        }
+      }
+    },
+    "/v2/nyt/nation_wide": {
+      "get": {
+        "tags": [
+          "NYT"
+        ],
+        "summary": "Get US Nationwide Data",
+        "description": "Return all NYT US nationwide data. Each entry returned represents data for a given day.",
+        "responses": {
+          "200": {
+            "description": "Status Ok",
+            "schema": {
+              "$ref": "#/definitions/nytCounties"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -711,6 +784,58 @@
         }
       }
     },
+    "nytState": {
+      "properties": {
+        "date": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "fips": {
+          "type": "string"
+        },
+        "cases": {
+          "type": "string"
+        },
+        "deaths": {
+          "type": "string"
+        }
+      }
+    },
+    "nytCounty": {
+      "properties": {
+        "date": {
+          "type": "string"
+        },
+        "county": {
+          "type": "county"
+        },
+        "state": {
+          "type": "string"
+        },
+        "fips": {
+          "type": "string"
+        },
+        "cases": {
+          "type": "string"
+        },
+        "deaths": {
+          "type": "string"
+        }
+      }
+    },
+    "nytTotal": {
+      "date": {
+        "type": "string"
+      },
+      "cases": {
+        "type": "string"
+      },
+      "deaths": {
+        "type": "string"
+      }
+    },
     "countries": {
       "type": "array",
       "items": {
@@ -727,6 +852,24 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/usaCounty"
+      }
+    },
+    "nytStates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/nytState"
+      }
+    },
+    "nytCounties": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/nytCounty"
+      }
+    },
+    "nytNationWide": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/nytTotal"
       }
     }
   },

--- a/config.example.json
+++ b/config.example.json
@@ -5,5 +5,6 @@
     "port": "6379"
   },
   "port": 3000,
-  "interval": 600000
+  "interval": 600000,
+  "nyt_interval": 72e6
 }

--- a/config.example.json
+++ b/config.example.json
@@ -6,5 +6,5 @@
   },
   "port": 3000,
   "interval": 600000,
-  "nyt_interval": 72e6
+  "nyt_interval": 36e5
 }

--- a/config.keys.json
+++ b/config.keys.json
@@ -8,7 +8,7 @@
   "jhu_v2": "covidapi:jhu_v2",
   "historical_v2": "covidapi:historical_v2",
   "historical_v2_USA": "covidapi:historical_v2_USA",
-  "nyt_counties": "covidapi:nyt:counties",
-  "nyt_states": "covidapi:nyt:states",
-  "nyt_USA": "covidapi:nyt:nation"
+  "nyt_counties": "covidapi:nyt_counties",
+  "nyt_states": "covidapi:nyt_states",
+  "nyt_USA": "covidapi:nyt_usa"
 }

--- a/config.keys.json
+++ b/config.keys.json
@@ -7,5 +7,8 @@
   "yesterday_states": "covidapi:yesterday_states",
   "jhu_v2": "covidapi:jhu_v2",
   "historical_v2": "covidapi:historical_v2",
-  "historical_v2_USA": "covidapi:historical_v2_USA"
+  "historical_v2_USA": "covidapi:historical_v2_USA",
+  "nyt_counties": "covidapi:nyt:counties",
+  "nyt_states": "covidapi:nyt:states",
+  "nyt_nationwide": "covidapi:nyt:nation"
 }

--- a/config.keys.json
+++ b/config.keys.json
@@ -10,5 +10,5 @@
   "historical_v2_USA": "covidapi:historical_v2_USA",
   "nyt_counties": "covidapi:nyt:counties",
   "nyt_states": "covidapi:nyt:states",
-  "nyt_nationwide": "covidapi:nyt:nation"
+  "nyt_USA": "covidapi:nyt:nation"
 }

--- a/routes/api_nyt.js
+++ b/routes/api_nyt.js
@@ -2,7 +2,7 @@
 const router = require('express').Router();
 const { nytCounties, nytStates, nytNationwide } = require('../utils/nyt_cache');
 
-router.get('/nyt/states', async (req, res) => {
+router.get('/v2/nyt/states', async (req, res) => {
 	const data = nytStates();
 	const { state: queryState } = req.query;
 	if (queryState) {
@@ -16,7 +16,7 @@ router.get('/nyt/states', async (req, res) => {
 	}
 });
 
-router.get('/nyt/counties', async (req, res) => {
+router.get('/v2/nyt/counties', async (req, res) => {
 	const data = nytCounties();
 	const { county: queryCounty } = req.query;
 	if (queryCounty) {
@@ -30,7 +30,7 @@ router.get('/nyt/counties', async (req, res) => {
 	}
 });
 
-router.get('nyt/nation_wide', async (req, res) => {
+router.get('/v2/nyt/nation_wide', async (req, res) => {
 	res.send(nytNationwide());
 });
 

--- a/routes/api_nyt.js
+++ b/routes/api_nyt.js
@@ -6,7 +6,8 @@ router.get('/v2/nyt/states', async (req, res) => {
 	const data = nytStates();
 	const { state: queryState } = req.query;
 	if (queryState) {
-		const stateData = data.filter(({ state }) => queryState === state);
+		const stateArr = queryState.split(/,[\s+]?/);
+		const stateData = data.filter(({ state }) => stateArr.includes(state));
 		// eslint-disable-next-line no-unused-expressions
 		stateData.length > 0
 			? res.send(stateData)
@@ -20,7 +21,8 @@ router.get('/v2/nyt/counties', async (req, res) => {
 	const data = nytCounties();
 	const { county: queryCounty } = req.query;
 	if (queryCounty) {
-		const countyData = data.filter(({ county }) => queryCounty === county);
+		const countyArr = queryCounty.split(/,[\s+?]/);
+		const countyData = data.filter(({ county }) => countyArr.includes(county));
 		// eslint-disable-next-line no-unused-expressions
 		countyData.length > 0
 			? res.send(countyData)
@@ -30,7 +32,7 @@ router.get('/v2/nyt/counties', async (req, res) => {
 	}
 });
 
-router.get('/v2/nyt/nation_wide', async (req, res) => {
+router.get('/v2/nyt/usa', async (req, res) => {
 	res.send(nytNationwide());
 });
 

--- a/routes/api_nyt.js
+++ b/routes/api_nyt.js
@@ -2,8 +2,8 @@
 const router = require('express').Router();
 const { nytCounties, nytStates, nytNationwide } = require('../utils/nyt_cache');
 
-router.get('/v2/nyt/states', async (req, res) => {
-	const { state: queryState } = req.query;
+router.get('/v2/nyt/states/:state', async (req, res) => {
+	const { state: queryState } = req.params;
 	const data = nytStates();
 	if (queryState) {
 		const stateArr = queryState.split(/,[\s+]?/).map((state) => state.toLowerCase());
@@ -17,8 +17,8 @@ router.get('/v2/nyt/states', async (req, res) => {
 	}
 });
 
-router.get('/v2/nyt/counties', async (req, res) => {
-	const { county: queryCounty } = req.query;
+router.get('/v2/nyt/counties/:county', async (req, res) => {
+	const { county: queryCounty } = req.params;
 	const data = nytCounties();
 	if (queryCounty) {
 		const countyArr = queryCounty.split(/,[\s+?]/).map((county) => county.toLowerCase());

--- a/routes/api_nyt.js
+++ b/routes/api_nyt.js
@@ -3,8 +3,8 @@ const router = require('express').Router();
 const { nytCounties, nytStates, nytNationwide } = require('../utils/nyt_cache');
 
 router.get('/v2/nyt/states', async (req, res) => {
-	const data = nytStates();
 	const { state: queryState } = req.query;
+	const data = nytStates();
 	if (queryState) {
 		const stateArr = queryState.split(/,[\s+]?/);
 		const stateData = data.filter(({ state }) => stateArr.includes(state));
@@ -18,8 +18,8 @@ router.get('/v2/nyt/states', async (req, res) => {
 });
 
 router.get('/v2/nyt/counties', async (req, res) => {
-	const data = nytCounties();
 	const { county: queryCounty } = req.query;
+	const data = nytCounties();
 	if (queryCounty) {
 		const countyArr = queryCounty.split(/,[\s+?]/);
 		const countyData = data.filter(({ county }) => countyArr.includes(county));
@@ -32,8 +32,6 @@ router.get('/v2/nyt/counties', async (req, res) => {
 	}
 });
 
-router.get('/v2/nyt/usa', async (req, res) => {
-	res.send(nytNationwide());
-});
+router.get('/v2/nyt/usa', async (req, res) => res.send(nytNationwide()));
 
 module.exports = router;

--- a/routes/api_nyt.js
+++ b/routes/api_nyt.js
@@ -1,0 +1,37 @@
+// eslint-disable-next-line new-cap
+const router = require('express').Router();
+const { nytCounties, nytStates, nytNationwide } = require('../utils/nyt_cache');
+
+router.get('/nyt/states', async (req, res) => {
+	const data = nytStates();
+	const { state: queryState } = req.query;
+	if (queryState) {
+		const stateData = data.filter(({ state }) => queryState === state);
+		// eslint-disable-next-line no-unused-expressions
+		stateData.length > 0
+			? res.send(stateData)
+			: res.status(404).send({ message: 'State not found or no data found for state' });
+	} else {
+		res.send(data);
+	}
+});
+
+router.get('/nyt/counties', async (req, res) => {
+	const data = nytCounties();
+	const { county: queryCounty } = req.query;
+	if (queryCounty) {
+		const countyData = data.filter(({ county }) => queryCounty === county);
+		// eslint-disable-next-line no-unused-expressions
+		countyData.length > 0
+			? res.send(countyData)
+			: res.status(404).send({ message: 'County not found or no data found for county' });
+	} else {
+		res.send(data);
+	}
+});
+
+router.get('nyt/nation_wide', async (req, res) => {
+	res.send(nytNationwide());
+});
+
+module.exports = router;

--- a/routes/api_nyt.js
+++ b/routes/api_nyt.js
@@ -6,8 +6,8 @@ router.get('/v2/nyt/states', async (req, res) => {
 	const { state: queryState } = req.query;
 	const data = nytStates();
 	if (queryState) {
-		const stateArr = queryState.split(/,[\s+]?/);
-		const stateData = data.filter(({ state }) => stateArr.includes(state));
+		const stateArr = queryState.split(/,[\s+]?/).map((state) => state.toLowerCase());
+		const stateData = data.filter(({ state }) => stateArr.includes(state.toLowerCase()));
 		// eslint-disable-next-line no-unused-expressions
 		stateData.length > 0
 			? res.send(stateData)
@@ -21,8 +21,8 @@ router.get('/v2/nyt/counties', async (req, res) => {
 	const { county: queryCounty } = req.query;
 	const data = nytCounties();
 	if (queryCounty) {
-		const countyArr = queryCounty.split(/,[\s+?]/);
-		const countyData = data.filter(({ county }) => countyArr.includes(county));
+		const countyArr = queryCounty.split(/,[\s+?]/).map((county) => county.toLowerCase());
+		const countyData = data.filter(({ county }) => countyArr.includes(county.toLowerCase()));
 		// eslint-disable-next-line no-unused-expressions
 		countyData.length > 0
 			? res.send(countyData)

--- a/routes/api_nyt.js
+++ b/routes/api_nyt.js
@@ -2,11 +2,13 @@
 const router = require('express').Router();
 const { nytCounties, nytStates, nytNationwide } = require('../utils/nyt_cache');
 
+router.get('/v2/nyt/states', async (req, res) => res.send(nytStates()));
+
 router.get('/v2/nyt/states/:state', async (req, res) => {
 	const { state: queryState } = req.params;
 	const data = nytStates();
 	if (queryState) {
-		const stateArr = queryState.split(/,[\s+]?/).map((state) => state.toLowerCase());
+		const stateArr = queryState.trim().split(/,[\s+]?/).map((state) => state.toLowerCase());
 		const stateData = data.filter(({ state }) => stateArr.includes(state.toLowerCase()));
 		// eslint-disable-next-line no-unused-expressions
 		stateData.length > 0
@@ -17,11 +19,13 @@ router.get('/v2/nyt/states/:state', async (req, res) => {
 	}
 });
 
+router.get('/v2/nyt/counties', async (req, res) => res.send(nytCounties()));
+
 router.get('/v2/nyt/counties/:county', async (req, res) => {
 	const { county: queryCounty } = req.params;
 	const data = nytCounties();
 	if (queryCounty) {
-		const countyArr = queryCounty.split(/,[\s+?]/).map((county) => county.toLowerCase());
+		const countyArr = queryCounty.trim().split(/,[\s+?]/).map((county) => county.toLowerCase());
 		const countyData = data.filter(({ county }) => countyArr.includes(county.toLowerCase()));
 		// eslint-disable-next-line no-unused-expressions
 		countyData.length > 0

--- a/routes/instances.js
+++ b/routes/instances.js
@@ -6,7 +6,7 @@ const getWorldometerPage = require('../scrapers/getWorldometers');
 const getStates = require('../scrapers/getStates');
 const jhuLocations = require('../scrapers/jhuLocations');
 const historical = require('../scrapers/historical');
-const { nytData } = require('../scrapers/nytData');
+const nytData = require('../scrapers/nytData');
 
 // KEYS
 const keys = require('../config.keys.json');

--- a/routes/instances.js
+++ b/routes/instances.js
@@ -6,6 +6,7 @@ const getWorldometerPage = require('../scrapers/getWorldometers');
 const getStates = require('../scrapers/getStates');
 const jhuLocations = require('../scrapers/jhuLocations');
 const historical = require('../scrapers/historical');
+const { nytData } = require('../scrapers/nytData');
 
 // KEYS
 const keys = require('../config.keys.json');
@@ -30,6 +31,7 @@ module.exports = {
 		getWorldometerPage,
 		getStates,
 		jhuLocations,
-		historical
+		historical,
+		nytData
 	}
 };

--- a/scrapers/nytData.js
+++ b/scrapers/nytData.js
@@ -1,0 +1,33 @@
+const axios = require('axios');
+const csv = require('csvtojson');
+const logger = require('../utils/logger');
+const { updateCache } = require('../utils/nyt_cache');
+
+const US_COUNTY_DATA_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv';
+const US_STATE_DATA_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv';
+const US_NATION_WIDE_DATA_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us.csv';
+const REDIS_KEYS = ['nyt_counties', 'nyt_states', 'nyt_nationwide'];
+
+const nytData = async (keys, redis) => {
+	try {
+		const _resolveData = async (url, index) => {
+			const { data } = await axios.get(url);
+			const parsedData = await csv().fromString(data);
+			redis.set(keys[REDIS_KEYS[index]], JSON.stringify(parsedData));
+		};
+
+		await Promise.all([
+			US_COUNTY_DATA_URL,
+			US_STATE_DATA_URL,
+			US_NATION_WIDE_DATA_URL
+		].map(_resolveData));
+		logger.info('NYT Data successfully retrieved');
+		await updateCache();
+	} catch (err) {
+		logger.err('Error: Requesting NYT data failed!', err);
+	}
+};
+
+module.exports = {
+	nytData
+};

--- a/scrapers/nytData.js
+++ b/scrapers/nytData.js
@@ -8,6 +8,11 @@ const US_STATE_DATA_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-da
 const US_NATION_WIDE_DATA_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us.csv';
 const REDIS_KEYS = ['nyt_counties', 'nyt_states', 'nyt_nationwide'];
 
+/**
+ * Retrieves NYT data from github and stores it in redis
+ * @param {Object} keys Redis keys sourced from configurations
+ * @param {Object} redis Redis instance
+ */
 const nytData = async (keys, redis) => {
 	try {
 		const _resolveData = async (url, index) => {
@@ -28,6 +33,4 @@ const nytData = async (keys, redis) => {
 	}
 };
 
-module.exports = {
-	nytData
-};
+module.exports = nytData;

--- a/scrapers/nytData.js
+++ b/scrapers/nytData.js
@@ -3,9 +3,10 @@ const csv = require('csvtojson');
 const logger = require('../utils/logger');
 const { updateCache } = require('../utils/nyt_cache');
 
-const US_COUNTY_DATA_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv';
-const US_STATE_DATA_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv';
-const US_NATION_WIDE_DATA_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us.csv';
+const GITHUB_BASE_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master'
+const US_COUNTY_DATA_URL = `${GITHUB_BASE_URL}/us-counties.csv`;
+const US_STATE_DATA_URL = `${GITHUB_BASE_URL}/us-states.csv`;
+const US_NATION_WIDE_DATA_URL = `${GITHUB_BASE_URL}/us.csv`;
 const REDIS_KEYS = ['nyt_counties', 'nyt_states', 'nyt_USA'];
 
 /**

--- a/scrapers/nytData.js
+++ b/scrapers/nytData.js
@@ -6,7 +6,7 @@ const { updateCache } = require('../utils/nyt_cache');
 const US_COUNTY_DATA_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv';
 const US_STATE_DATA_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv';
 const US_NATION_WIDE_DATA_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master/us.csv';
-const REDIS_KEYS = ['nyt_counties', 'nyt_states', 'nyt_nationwide'];
+const REDIS_KEYS = ['nyt_counties', 'nyt_states', 'nyt_USA'];
 
 /**
  * Retrieves NYT data from github and stores it in redis

--- a/scrapers/nytData.js
+++ b/scrapers/nytData.js
@@ -3,7 +3,7 @@ const csv = require('csvtojson');
 const logger = require('../utils/logger');
 const { updateCache } = require('../utils/nyt_cache');
 
-const GITHUB_BASE_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master'
+const GITHUB_BASE_URL = 'https://raw.githubusercontent.com/nytimes/covid-19-data/master';
 const US_COUNTY_DATA_URL = `${GITHUB_BASE_URL}/us-counties.csv`;
 const US_STATE_DATA_URL = `${GITHUB_BASE_URL}/us-states.csv`;
 const US_NATION_WIDE_DATA_URL = `${GITHUB_BASE_URL}/us.csv`;

--- a/server.js
+++ b/server.js
@@ -17,8 +17,13 @@ const execAll = async () => {
 	app.emit('scrapper_finished');
 };
 
+const execNyt = () => scraper.nytData(keys, redis);
+
 execAll();
+execNyt();
+
 setInterval(execAll, config.interval);
+setInterval(execNyt, config.nyt_interval);
 
 app.use(cors());
 app.get('/', async (req, res) => res.redirect('https://github.com/novelcovid/api'));
@@ -56,6 +61,7 @@ app.use(require('./routes/api_worldometers'));
 app.use(require('./routes/api_historical'));
 app.use(require('./routes/api_jhucsse'));
 app.use(require('./routes/api_deprecated'));
+app.use(require('./routes/api_nyt'));
 
 app.listen(config.port, () =>
 	logger.info(`Your app is listening on port ${config.port}`)

--- a/server.js
+++ b/server.js
@@ -19,7 +19,9 @@ const execAll = async () => {
 
 const execNyt = () => scraper.nytData(keys, redis);
 
+// Update Worldometer and Johns Hopkins data every 10 minutes
 execAll();
+// Update NYT data every hour
 execNyt();
 
 setInterval(execAll, config.interval);

--- a/server.js
+++ b/server.js
@@ -19,12 +19,12 @@ const execAll = async () => {
 
 const execNyt = () => scraper.nytData(keys, redis);
 
-// Update Worldometer and Johns Hopkins data every 10 minutes
 execAll();
-// Update NYT data every hour
 execNyt();
 
+// Update Worldometer and Johns Hopkins data every 10 minutes
 setInterval(execAll, config.interval);
+// Update NYT data every hour
 setInterval(execNyt, config.nyt_interval);
 
 app.use(cors());

--- a/tests/api_nyt.spec.js
+++ b/tests/api_nyt.spec.js
@@ -1,0 +1,97 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const app = require('../server');
+const should = chai.should();
+chai.use(chaiHttp);
+
+describe('TESTING /nyt/states', () => {
+    it('/nyt/states', (done) => {
+        chai.request(app)
+            .get('/nyt/states')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.should.have.status(200);
+                res.body.should.be.a('array');
+                done();
+            })
+    })
+
+    it('/nyt/states get correct state', (done) => {
+        chai.request(app)
+            .get('/nyt/states?state=California')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.body.should.be.a('array');
+                res.body[0].should.have.property('state').equal('California');
+                done();
+            })
+    })
+
+    it('/nyt/states get incorrect state name', (done) => {
+        chai.request(app)
+            .get('/nyt/states?state=DoesntExist')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.should.have.status(404);
+                res.body.should.be.a('object');
+                res.body.should.have.property('message');
+                done();
+            });
+    });
+});
+
+describe('TESTING /counties', (done) => {
+    it('/nyt/counties', (done) => {
+        chai.request(app)
+            .get('/nyt/counties')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.should.have.status(200);
+                res.body.should.be.a('array');
+                done();
+            });
+    });
+
+    it('/nyt/counties get correct county', (done) => {
+        chai.request(app)
+            .get('/nyt/counties?county=Alameda')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.body.should.be.a('array');
+                res.body[0].should.have.property('county').equal('Alameda');
+                done();
+            });
+    });
+
+    it('/nyt/counties get incorrect county name', (done) => {
+        chai.request(app)
+            .get('/nyt/counties?county=DoesntExist')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.should.have.status(404);
+                res.body.should.be.a('object');
+                res.body.should.have.property('message');
+                done();
+            });
+    });
+});
+
+describe('TESTING /nyt/nation_wide', () => {
+    it('/nyt/nation_wide', (done) => {
+        chai.request(app)
+            .get('/nyt/nation_wide')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.should.have.status(200);
+                res.body.should.be.a('array');
+                done();
+            });
+    })
+});

--- a/tests/api_nyt.spec.js
+++ b/tests/api_nyt.spec.js
@@ -82,10 +82,10 @@ describe('TESTING /v2/counties', (done) => {
     });
 });
 
-describe('TESTING /v2/nyt/nation_wide', () => {
-    it('/v2/nyt/nation_wide', (done) => {
+describe('TESTING /v2/nyt/usa', () => {
+    it('/v2/nyt/usa', (done) => {
         chai.request(app)
-            .get('/v2/nyt/nation_wide')
+            .get('/v2/nyt/usa')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);

--- a/tests/api_nyt.spec.js
+++ b/tests/api_nyt.spec.js
@@ -63,8 +63,8 @@ describe('TESTING /v2/nyt/states', () => {
                 res.body.should.be.a('array');
                 let illinoisFound = false, californiaFound = false;
                 res.body.map((entry) => {
-                    if (entry.county === 'Illinois') illinoisFound = illinoisFound || true;
-                    if (entry.county === 'California') californiaFound = californiaFound || true;
+                    if (entry.state === 'Illinois') illinoisFound = illinoisFound || true;
+                    if (entry.state === 'California') californiaFound = californiaFound || true;
                 });
                 (illinoisFound && californiaFound).should.equal(true);
                 done();
@@ -80,7 +80,7 @@ describe('TESTING /v2/nyt/states', () => {
                 res.body.should.be.a('array');
                 let illinoisFound = false;
                 res.body.map((entry) => {
-                    if (entry.county === 'Illinois') illinoisFound = illinoisFound || true;
+                    if (entry.state === 'Illinois') illinoisFound = illinoisFound || true;
                 });
                 (illinoisFound).should.equal(true);
                 done();

--- a/tests/api_nyt.spec.js
+++ b/tests/api_nyt.spec.js
@@ -15,11 +15,11 @@ describe('TESTING /v2/nyt/states', () => {
                 res.body.should.be.a('array');
                 done();
             })
-    })
+    });
 
     it('/v2/nyt/states get correct state', (done) => {
         chai.request(app)
-            .get('/v2/nyt/states?state=California')
+            .get('/v2/nyt/states/California')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);
@@ -27,17 +27,62 @@ describe('TESTING /v2/nyt/states', () => {
                 res.body[0].should.have.property('state').equal('California');
                 done();
             })
-    })
+    });
+
+    it('/v2/nyt/states get correct state lowercase', (done) => {
+        chai.request(app)
+            .get('/v2/nyt/states/cAlifornia')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.body.should.be.a('array');
+                res.body[0].should.have.property('state').equal('California');
+                done();
+            })
+    });
 
     it('/v2/nyt/states get incorrect state name', (done) => {
         chai.request(app)
-            .get('/v2/nyt/states?state=DoesntExist')
+            .get('/v2/nyt/states/DoesntExist')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);
                 res.should.have.status(404);
                 res.body.should.be.a('object');
                 res.body.should.have.property('message');
+                done();
+            });
+    });
+
+    it('/v2/nyt/states multiple correct states', (done) => {
+        chai.request(app)
+            .get('/v2/nyt/states/illinois,california')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.body.should.be.a('array');
+                let illinoisFound, californiaFound = false;
+                res.body.map((entry) => {
+                    if (entry.county === 'Illinois') illinoisFound = illinoisFound || true;
+                    if (entry.county === 'California') californiaFound = californiaFound || true;
+                });
+                (illinoisFound && californiaFound).should.equal(true);
+                done();
+            });
+    });
+
+    it('/v2/nyt/states partial incorrect states', (done) => {
+        chai.request(app)
+            .get('/v2/nyt/states/illinois,incorrect')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.body.should.be.a('array');
+                let illinoisFound = false;
+                res.body.map((entry) => {
+                    if (entry.county === 'Illinois') illinoisFound = illinoisFound || true;
+                });
+                (illinoisFound).should.equal(true);
                 done();
             });
     });
@@ -58,7 +103,7 @@ describe('TESTING /v2/counties', (done) => {
 
     it('/v2/nyt/counties get correct county', (done) => {
         chai.request(app)
-            .get('/v2/nyt/counties?county=Alameda')
+            .get('/v2/nyt/counties/Alameda')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);
@@ -68,9 +113,54 @@ describe('TESTING /v2/counties', (done) => {
             });
     });
 
+    it('/v2/nyt/counties get correct county lowercase', (done) => {
+        chai.request(app)
+            .get('/v2/nyt/counties/aLamEda')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.body.should.be.a('array');
+                res.body[0].should.have.property('county').equal('Alameda');
+                done();
+            });
+    });
+
+    it('/v2/nyt/counties multiple correct counties', (done) => {
+        chai.request(app)
+            .get('/v2/nyt/counties/aLamEda,cook')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.body.should.be.a('array');
+                let cookFound, alamedaFound = false;
+                res.body.map((entry) => {
+                    if (entry.county === 'Cook') cookFound = cookFound || true;
+                    if (entry.county === 'Alameda') alamedaFound = alamedaFound || true;
+                });
+                (cookFound && alamedaFound).should.equal(true);
+                done();
+            });
+    });
+
+    it('/v2/nyt/counties partial incorrect counties', (done) => {
+        chai.request(app)
+            .get('/v2/nyt/counties/incorrect,cook')
+            .end((err, res) => {
+                should.not.exist(err);
+                should.exist(res);
+                res.body.should.be.a('array');
+                let cookFound = false;
+                res.body.map((entry) => {
+                    if (entry.county === 'Cook') cookFound = cookFound || true;
+                });
+                cookFound.should.equal(true);
+                done();
+            });
+    });
+
     it('/v2/nyt/counties get incorrect county name', (done) => {
         chai.request(app)
-            .get('/v2/nyt/counties?county=DoesntExist')
+            .get('/v2/nyt/counties/DoesntExist')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);

--- a/tests/api_nyt.spec.js
+++ b/tests/api_nyt.spec.js
@@ -4,10 +4,10 @@ const app = require('../server');
 const should = chai.should();
 chai.use(chaiHttp);
 
-describe('TESTING /nyt/states', () => {
-    it('/nyt/states', (done) => {
+describe('TESTING /v2/nyt/states', () => {
+    it('/v2/nyt/states', (done) => {
         chai.request(app)
-            .get('/nyt/states')
+            .get('/v2/nyt/states')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);
@@ -17,9 +17,9 @@ describe('TESTING /nyt/states', () => {
             })
     })
 
-    it('/nyt/states get correct state', (done) => {
+    it('/v2/nyt/states get correct state', (done) => {
         chai.request(app)
-            .get('/nyt/states?state=California')
+            .get('/v2/nyt/states?state=California')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);
@@ -29,9 +29,9 @@ describe('TESTING /nyt/states', () => {
             })
     })
 
-    it('/nyt/states get incorrect state name', (done) => {
+    it('/v2/nyt/states get incorrect state name', (done) => {
         chai.request(app)
-            .get('/nyt/states?state=DoesntExist')
+            .get('/v2/nyt/states?state=DoesntExist')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);
@@ -43,10 +43,10 @@ describe('TESTING /nyt/states', () => {
     });
 });
 
-describe('TESTING /counties', (done) => {
-    it('/nyt/counties', (done) => {
+describe('TESTING /v2/counties', (done) => {
+    it('/v2/nyt/counties', (done) => {
         chai.request(app)
-            .get('/nyt/counties')
+            .get('/v2/nyt/counties')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);
@@ -56,9 +56,9 @@ describe('TESTING /counties', (done) => {
             });
     });
 
-    it('/nyt/counties get correct county', (done) => {
+    it('/v2/nyt/counties get correct county', (done) => {
         chai.request(app)
-            .get('/nyt/counties?county=Alameda')
+            .get('/v2/nyt/counties?county=Alameda')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);
@@ -68,9 +68,9 @@ describe('TESTING /counties', (done) => {
             });
     });
 
-    it('/nyt/counties get incorrect county name', (done) => {
+    it('/v2/nyt/counties get incorrect county name', (done) => {
         chai.request(app)
-            .get('/nyt/counties?county=DoesntExist')
+            .get('/v2/nyt/counties?county=DoesntExist')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);
@@ -82,10 +82,10 @@ describe('TESTING /counties', (done) => {
     });
 });
 
-describe('TESTING /nyt/nation_wide', () => {
-    it('/nyt/nation_wide', (done) => {
+describe('TESTING /v2/nyt/nation_wide', () => {
+    it('/v2/nyt/nation_wide', (done) => {
         chai.request(app)
-            .get('/nyt/nation_wide')
+            .get('/v2/nyt/nation_wide')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);

--- a/tests/api_nyt.spec.js
+++ b/tests/api_nyt.spec.js
@@ -61,7 +61,7 @@ describe('TESTING /v2/nyt/states', () => {
                 should.not.exist(err);
                 should.exist(res);
                 res.body.should.be.a('array');
-                let illinoisFound, californiaFound = false;
+                let illinoisFound = false, californiaFound = false;
                 res.body.map((entry) => {
                     if (entry.county === 'Illinois') illinoisFound = illinoisFound || true;
                     if (entry.county === 'California') californiaFound = californiaFound || true;
@@ -132,7 +132,7 @@ describe('TESTING /v2/counties', (done) => {
                 should.not.exist(err);
                 should.exist(res);
                 res.body.should.be.a('array');
-                let cookFound, alamedaFound = false;
+                let cookFound = false, alamedaFound = false;
                 res.body.map((entry) => {
                     if (entry.county === 'Cook') cookFound = cookFound || true;
                     if (entry.county === 'Alameda') alamedaFound = alamedaFound || true;

--- a/tests/api_nyt.spec.js
+++ b/tests/api_nyt.spec.js
@@ -56,7 +56,7 @@ describe('TESTING /v2/nyt/states', () => {
 
     it('/v2/nyt/states multiple correct states', (done) => {
         chai.request(app)
-            .get('/v2/nyt/states/illinois,california')
+            .get('/v2/nyt/states/illinois, california')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);
@@ -73,7 +73,7 @@ describe('TESTING /v2/nyt/states', () => {
 
     it('/v2/nyt/states partial incorrect states', (done) => {
         chai.request(app)
-            .get('/v2/nyt/states/illinois,incorrect')
+            .get('/v2/nyt/states/illinois, incorrect')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);
@@ -127,7 +127,7 @@ describe('TESTING /v2/counties', (done) => {
 
     it('/v2/nyt/counties multiple correct counties', (done) => {
         chai.request(app)
-            .get('/v2/nyt/counties/aLamEda,cook')
+            .get('/v2/nyt/counties/aLamEda, cook')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);
@@ -144,7 +144,7 @@ describe('TESTING /v2/counties', (done) => {
 
     it('/v2/nyt/counties partial incorrect counties', (done) => {
         chai.request(app)
-            .get('/v2/nyt/counties/incorrect,cook')
+            .get('/v2/nyt/counties/incorrect, cook')
             .end((err, res) => {
                 should.not.exist(err);
                 should.exist(res);

--- a/utils/nyt_cache.js
+++ b/utils/nyt_cache.js
@@ -22,7 +22,7 @@ exports.updateCache = async () => {
 		const [parsedCountyData, parsedStateData, parsedNationData] = await Promise.all([
 			keys.nyt_counties,
 			keys.nyt_states,
-			keys.nyt_nationwide
+			keys.nyt_USA
 		].map(async (key) => JSON.parse(await redis.get(key))));
 		this.currentStatus.nytCounties = parsedCountyData;
 		this.currentStatus.nytStates = parsedStateData;

--- a/utils/nyt_cache.js
+++ b/utils/nyt_cache.js
@@ -2,7 +2,7 @@
 Local cache to avoid unnecessary JSON parsing during NYT data retrieval
 Status of cache will update every time data is successfully scraped
 */
-
+const logger = require('../utils/logger');
 
 exports.currentStatus = {
 	nytCounties: undefined,
@@ -15,15 +15,21 @@ exports.nytCounties = () => this.currentStatus.nytCounties;
 exports.nytStates = () => this.currentStatus.nytStates;
 exports.nytNationwide = () => this.currentStatus.nytNationwide;
 
+// Retrieves NYT data from Redis and stores it locally when 
 exports.updateCache = async () => {
-	const { redis, keys } = require('../routes/instances');
-	const [parsedCountyData, parsedStateData, parsedNationData] = await Promise.all([
-		keys.nyt_counties,
-		keys.nyt_states,
-		keys.nyt_nationwide
-	].map(async (key) => JSON.parse(await redis.get(key))));
-	this.currentStatus.nytCounties = parsedCountyData;
-	this.currentStatus.nytStates = parsedStateData;
-	this.currentStatus.nytNationwide = parsedNationData;
+	try {
+		const { redis, keys } = require('../routes/instances');
+		const [parsedCountyData, parsedStateData, parsedNationData] = await Promise.all([
+			keys.nyt_counties,
+			keys.nyt_states,
+			keys.nyt_nationwide
+		].map(async (key) => JSON.parse(await redis.get(key))));
+		this.currentStatus.nytCounties = parsedCountyData;
+		this.currentStatus.nytStates = parsedStateData;
+		this.currentStatus.nytNationwide = parsedNationData;
+		logger.info('NYT local cache updated');
+	} catch (err) {
+		logger.err('Local NYT cache update failed', err)
+	}
 };
 

--- a/utils/nyt_cache.js
+++ b/utils/nyt_cache.js
@@ -1,0 +1,29 @@
+/*
+Local cache to avoid unnecessary JSON parsing during NYT data retrieval
+Status of cache will update every time data is successfully scraped
+*/
+
+
+exports.currentStatus = {
+	nytCounties: undefined,
+	nytStates: undefined,
+	nytNationwide: undefined
+};
+
+// Series of get calls to retrieve current state of cache
+exports.nytCounties = () => this.currentStatus.nytCounties;
+exports.nytStates = () => this.currentStatus.nytStates;
+exports.nytNationwide = () => this.currentStatus.nytNationwide;
+
+exports.updateCache = async () => {
+	const { redis, keys } = require('../routes/instances');
+	const [parsedCountyData, parsedStateData, parsedNationData] = await Promise.all([
+		keys.nyt_counties,
+		keys.nyt_states,
+		keys.nyt_nationwide
+	].map(async (key) => JSON.parse(await redis.get(key))));
+	this.currentStatus.nytCounties = parsedCountyData;
+	this.currentStatus.nytStates = parsedStateData;
+	this.currentStatus.nytNationwide = parsedNationData;
+};
+

--- a/utils/nyt_cache.js
+++ b/utils/nyt_cache.js
@@ -15,7 +15,7 @@ exports.nytCounties = () => this.currentStatus.nytCounties;
 exports.nytStates = () => this.currentStatus.nytStates;
 exports.nytNationwide = () => this.currentStatus.nytNationwide;
 
-// Retrieves NYT data from Redis and stores it locally when 
+// Retrieves NYT data from Redis and stores it locally when data is updated
 exports.updateCache = async () => {
 	try {
 		const { redis, keys } = require('../routes/instances');
@@ -29,7 +29,7 @@ exports.updateCache = async () => {
 		this.currentStatus.nytNationwide = parsedNationData;
 		logger.info('NYT local cache updated');
 	} catch (err) {
-		logger.err('Local NYT cache update failed', err)
+		logger.err('Local NYT cache update failed', err);
 	}
 };
 


### PR DESCRIPTION
This PR adds the following routes:

`/v2/nyt/states`
`/v2/nyt/counties`
`/v2/nyt/usa`

This allows users to optionally query for NYT data rather than Johns Hopkins or Worldometer if they so choose.

Some extra thoughts:
- The state and county routes currently support looking up ALL state/county data, or data for a single state/county. Maybe we want to include the option to look up multiple states/counties at once? 
- Do we want to add functionality to the `node-api` package as well?
- We'll need to update the deployed version of the `config.json` to add the `nyt_interval` before any changes are deployed