### PR TITLE
update NYT local cache when booting up API

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,8 +8,12 @@ const bodyParser = require('body-parser');
 const logger = require('./utils/logger');
 const path = require('path');
 const { config, port } = require('./routes/instances');
+const { updateCache } = require('./utils/nyt_cache');
 
 if (config.sentry_key) Sentry.init({ dsn: config.sentry_key });
+
+// Use local cache for NYT data
+updateCache();
 
 app.use(require('cors')());
 app.use(express.static(path.join(__dirname, '/public')));


### PR DESCRIPTION
Currently, local cache is only being updated when data is scraped. Since the scraper and the API are separate services now, we need to run the script to update the cache when the API boots up.