### PR TITLE
save empty Worldometer values as null instead of zero

### DIFF
--- a/scrapers/getWorldometers.js
+++ b/scrapers/getWorldometers.js
@@ -47,7 +47,7 @@ const mapRows = (_, row) => {
 				break;
 
 			default:
-				country[columns[index - 1]] = cell.text() === '' ? null : (parseInt(cell.text().replace(/(\n|,)/g, '')) || 0);
+				country[columns[index - 1]] = isNaN(parseInt(cell.text().replace(/(\n|,)/g, ''))) ? null : parseInt(cell.text().replace(/(\n|,)/g, ''));
 		}
 	});
 	return country;

--- a/scrapers/getWorldometers.js
+++ b/scrapers/getWorldometers.js
@@ -47,7 +47,7 @@ const mapRows = (_, row) => {
 				break;
 
 			default:
-				country[columns[index - 1]] = parseInt(cell.text().replace(/(\n|,)/g, '')) || 0;
+				country[columns[index - 1]] = cell.text() === '' ? null : (parseInt(cell.text().replace(/(\n|,)/g, '')) || 0);
 		}
 	});
 	return country;


### PR DESCRIPTION
Worldometer data resets for the day at GMT midnight and all "today" values reset to empty. The api returns 0 when cases actually haven't been reported yet. This change returns null instead of zero in those cases. What do you think?