### PR TITLE
Added RUN IN POSTMAN button

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 ## Recommended by Postman
 NovelCovid API is recommended by Postman [here](https://covid-19-apis.postman.com/)
 
+[![Run in Postman](https://run-beta.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/11144369-e27366d6-7699-46f4-b58e-2b2b2e637be5-Szf6Z9B3)
+
 ## Documentation
 NovelCovid API Documentation can be found [here](https://disease.sh/docs/)
 


### PR DESCRIPTION
Sharing the Postman collection via `Run in Postman` button is easier. 
Anyone **can import** and **run this collection** with **one click**.

Changes made: Added a **`Run In Postman`** button in `README.md`

[![Run in Postman](https://run-beta.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/11144369-e27366d6-7699-46f4-b58e-2b2b2e637be5-Szf6Z9B3)

> Learn more [here](https://learning.postman.com/docs/postman-for-publishers/run-in-postman/creating-run-button/).