### PR TITLE
Influenza CDC Data

### DIFF
--- a/config/config.keys.json
+++ b/config/config.keys.json
@@ -15,5 +15,8 @@
   "nyt_USA": "covidapi:nyt_usa",
   "apple_all": "covidapi:apple_all",
   "gov_countries": "covidapi:gov_countries",
-  "ebola_ecdc": "ebola:ecdc"
+  "ebola_ecdc": "ebola:ecdc",
+  "influenza_ILINET": "influenza:ILINET",
+  "influenza_USPHL": "influenza:USPHL",
+  "influenza_USCL": "influenza:USCL"
 }

--- a/config/index.js
+++ b/config/index.js
@@ -30,6 +30,8 @@ config.apple_interval = process.env.APPLE_INTERVAL || 864e5;
 config.gov_interval = process.env.GOV_INTERVAL || 864e5;
 // eslint-disable-next-line camelcase
 config.ebola_interval = process.env.EBOLA_INTERVAL || 864e5;
+// eslint-disable-next-line camelcase
+config.CDC_interval = process.env.CDC_INTERVAL || 864e5;
 
 // SENTRY KEY (ONLY FOR PRODUCTION)
 // eslint-disable-next-line camelcase

--- a/public/apidocs/swagger_v3.json
+++ b/public/apidocs/swagger_v3.json
@@ -39,6 +39,10 @@
       {
         "name": "Ebola ECDC",
         "description": "(Ebola virus outbreak data reported by the European Centre for Disease Control, updated every 24 hours)"
+      },
+      {
+        "name": "Influenza CDC",
+        "description": "(Influenza data reported by the United States CDC, updated every 24 hours)"
       }
     ],
     "consumes": [
@@ -48,7 +52,7 @@
       "application/json"
     ],
     "paths": {
-      "/v2/all": {
+      "/v3/covid-19/all": {
         "get": {
           "tags": [
             "Covid-19: Worldometers"
@@ -92,7 +96,7 @@
           }
         }
       },
-      "/v2/states": {
+      "/v3/covid-19/states": {
         "get": {
           "tags": [
             "Covid-19: Worldometers"
@@ -137,7 +141,7 @@
           }
         }
       },
-      "/v2/states/{states}": {
+      "/v3/covid-19/states/{states}": {
         "get": {
           "tags": [
             "Covid-19: Worldometers"
@@ -175,7 +179,7 @@
           }
         }
       },
-      "/v2/continents": {
+      "/v3/covid-19/continents": {
         "get": {
           "tags": [
             "Covid-19: Worldometers"
@@ -237,7 +241,7 @@
           }
         }
       },
-      "/v2/continents/{query}": {
+      "/v3/covid-19/continents/{query}": {
         "get": {
           "tags": [
             "Covid-19: Worldometers"
@@ -298,7 +302,7 @@
           }
         }
       },
-      "/v2/countries": {
+      "/v3/covid-19/countries": {
         "get": {
           "tags": [
             "Covid-19: Worldometers"
@@ -349,7 +353,7 @@
               "type": "string"
             }
           ],
-          "summary": "Get Covid-19 totals for all countries",          "responses": {
+          "summary": "Get Covid-19 totals for all countries",
             "responses": {
             "200": {
               "description": "Status OK",
@@ -360,7 +364,7 @@
           }
         }
       },
-      "/v2/countries/{query}": {
+      "/v3/covid-19/countries/{query}": {
         "get": {
           "tags": [
             "Covid-19: Worldometers"
@@ -422,7 +426,7 @@
           }
         }
       },
-      "/v2/countries/{country,country,...}": {
+      "/v3/covid-19/countries/{country,country,...}": {
         "get": {
           "tags": [
             "Covid-19: Worldometers"
@@ -473,7 +477,7 @@
           }
         }
       },
-      "/v2/jhucsse": {
+      "/v3/covid-19/jhucsse": {
         "get": {
           "tags": [
             "Covid-19 JHUCSSE"
@@ -489,7 +493,7 @@
           }
         }
       },
-      "/v2/jhucsse/counties": {
+      "/v3/covid-19/jhucsse/counties": {
         "get": {
           "tags": [
             "Covid-19 JHUCSSE"
@@ -505,7 +509,7 @@
           }
         }
       },
-      "/v2/jhucsse/counties/countyName": {
+      "/v3/covid-19/jhucsse/counties/countyName": {
         "get": {
           "tags": [
             "Covid-19 JHUCSSE"
@@ -530,7 +534,7 @@
           }
         }
       },
-      "/v2/historical": {
+      "/v3/covid-19/historical": {
         "get": {
           "tags": [
             "Covid-19 JHUCSSE"
@@ -556,7 +560,7 @@
           }
         }
       },
-      "/v2/historical/all": {
+      "/v3/covid-19/historical/all": {
         "get": {
           "tags": [
             "Covid-19 JHUCSSE"
@@ -579,7 +583,7 @@
           }
         }
       },
-      "/v2/historical/usacounties": {
+      "/v3/covid-19/historical/usacounties": {
         "get": {
           "tags": [
             "Covid-19 JHUCSSE"
@@ -593,7 +597,7 @@
           }
         }
       },
-      "/v2/historical/usacounties/{state}": {
+      "/v3/covid-19/historical/usacounties/{state}": {
         "get": {
           "tags": [
             "Covid-19 JHUCSSE"
@@ -603,7 +607,7 @@
               "name": "state",
               "in": "path",
               "required": true,
-              "description": "US state name, validated in the array returned from /v2/historical/usacounties",
+              "description": "US state name, validated in the array returned from /v3/covid-19/historical/usacounties",
               "type": "string"
             },
             {
@@ -626,7 +630,7 @@
           }
         }
       },
-      "/v2/historical/{query}": {
+      "/v3/covid-19/historical/{query}": {
         "get": {
           "tags": [
             "Covid-19 JHUCSSE"
@@ -659,7 +663,7 @@
           }
         }
       },
-      "/v2/historical/{country,country,...}": {
+      "/v3/covid-19/historical/{country,country,...}": {
         "get": {
           "tags": [
             "Covid-19 JHUCSSE"
@@ -689,7 +693,7 @@
           }
         }
       },
-      "/v2/historical/{query}/{province}": {
+      "/v3/covid-19/historical/{query}/{province}": {
         "get": {
           "tags": [
             "Covid-19 JHUCSSE"
@@ -706,7 +710,7 @@
               "name": "province",
               "in": "path",
               "required": true,
-              "description": "Province name, can be found in /v2/historical/{query} result",
+              "description": "Province name, can be found in /v3/covid-19/historical/{query} result",
               "type": "string"
             },
             {
@@ -726,7 +730,7 @@
           }
         }
       },
-      "/v2/historical/{query}/{province,province,...}": {
+      "/v3/covid-19/historical/{query}/{province,province,...}": {
         "get": {
           "tags": [
             "Covid-19 JHUCSSE"
@@ -763,7 +767,7 @@
           }
         }
       },
-      "/v2/nyt/states": {
+      "/v3/covid-19/nyt/states": {
         "get": {
           "tags": [
             "Covid-19 NYT"
@@ -788,7 +792,7 @@
           }
         }
       },
-      "/v2/nyt/counties": {
+      "/v3/covid-19/nyt/counties": {
         "get": {
           "tags": [
             "Covid-19 NYT"
@@ -813,7 +817,7 @@
           }
         }
       },
-      "/v2/nyt/usa": {
+      "/v3/covid-19/nyt/usa": {
         "get": {
           "tags": [
             "Covid-19 NYT"
@@ -829,7 +833,7 @@
           }
         }
       },
-      "/v2/apple/countries": {
+      "/v3/covid-19/apple/countries": {
         "get": {
           "tags": [
             "Covid-19 Apple"
@@ -843,7 +847,7 @@
           }
         }
       },
-      "/v2/apple/countries/{country}": {
+      "/v3/covid-19/apple/countries/{country}": {
         "get": {
           "tags": [
             "Covid-19 Apple"
@@ -853,7 +857,7 @@
               "name": "country",
               "in": "path",
               "required": true,
-              "description": "Any valid country name supported by the endpoint. Supported countries can be found in /v2/apple/countres",
+              "description": "Any valid country name supported by the endpoint. Supported countries can be found in /v3/covid-19/apple/countres",
               "type": "string"
             }
           ],
@@ -869,7 +873,7 @@
           }
         }
       },
-      "/v2/apple/countries/{country}/{subregions}": {
+      "/v3/covid-19/apple/countries/{country}/{subregions}": {
         "get": {
           "tags": [
             "Covid-19 Apple"
@@ -879,14 +883,14 @@
               "name": "country",
               "in": "path",
               "required": true,
-              "description": "Any valid country name supported by the endpoint. Supported countries can be found in /v2/apple/countres",
+              "description": "Any valid country name supported by the endpoint. Supported countries can be found in /v3/covid-19/apple/countres",
               "type": "string"
             },
             {
               "name": "subregions",
               "in": "path",
               "required": true,
-              "description": "Comma separated subregions supported by country for apple mobility data. Can find available subregions on /v2/apple/countries/{country} endpoint",
+              "description": "Comma separated subregions supported by country for apple mobility data. Can find available subregions on /v3/covid-19/apple/countries/{country} endpoint",
               "type": "string"
             }
           ],
@@ -902,7 +906,7 @@
           }
         }
       },
-      "/v2/gov/": {
+      "/v3/covid-19/gov/": {
         "get": {
           "tags": [
             "Covid-19 Government"
@@ -916,7 +920,7 @@
           }
         }
       },
-      "/v2/gov/{country}": {
+      "/v3/covid-19/gov/{country}": {
         "get": {
           "tags": [
             "Covid-19 Government"
@@ -926,7 +930,7 @@
               "name": "country",
               "in": "path",
               "required": true,
-              "description": "Any valid country name supported by the endpoint. Supported countries can be found in /v2/gov/",
+              "description": "Any valid country name supported by the endpoint. Supported countries can be found in /v3/covid-19/gov/",
               "type": "string"
             }
           ],
@@ -938,7 +942,7 @@
           }
         }
       },
-      "/v2/ebola": {
+      "/v3/ebola/ecdc": {
         "get": {
           "tags": [
             "Ebola ECDC"
@@ -964,6 +968,54 @@
               "description": "Status Ok",
               "schema": {
                 "$ref": "#/definitions/ebola"
+              }
+            }
+          }
+        }
+      },
+      "/v3/influenza/cdc/ILINet": {
+        "get": {
+          "tags": [
+            "Influenza CDC"
+          ],
+          "summary": "Get Influenza-like-illness data for the 2019 and 2020 outbreaks from the US Center for Disease Control",
+          "responses": {
+            "200": {
+              "description": "Status Ok",
+              "schema": {
+                "$ref": "#/definitions/influenzaILINet"
+              }
+            }
+          }
+        }
+      },
+      "/v3/influenza/cdc/USCL": {
+        "get": {
+          "tags": [
+            "Influenza CDC"
+          ],
+          "summary": "Get Influenza report data for the 2019 and 2020 outbreaks from the US Center for Disease Control, reported by US clinical labs",
+          "responses": {
+            "200": {
+              "description": "Status Ok",
+              "schema": {
+                "$ref": "#/definitions/influenzaUSCL"
+              }
+            }
+          }
+        }
+      },
+      "/v3/influenza/cdc/USPHL": {
+        "get": {
+          "tags": [
+            "Influenza CDC"
+          ],
+          "summary": "Get Influenza report data for the 2019 and 2020 outbreaks from the US Center for Disease Control, reported by US public health labs",
+          "responses": {
+            "200": {
+              "description": "Status Ok",
+              "schema": {
+                "$ref": "#/definitions/influenzaUSPHL"
               }
             }
           }
@@ -1262,13 +1314,13 @@
             "type": "string"
           },
           "driving": {
-            "type": "float"
+            "type": "number"
           },
           "transit": {
-            "type": "float"
+            "type": "number"
           },
           "walking": {
-            "type": "float"
+            "type": "number"
           }
         }
       },
@@ -1320,6 +1372,138 @@
             "items": {
               "$ref": "#/definitions/ebolaProvince"
             }
+          }
+        }
+      },
+      "influenzaILINet": {
+        "properties": {
+          "updated": {
+            "type":  "number"
+          },
+          "source": {
+            "type": "string"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/definitions/ILINet"
+            }
+          }
+        }
+      },
+      "ILINet": {
+        "properties": {
+          "week": {
+            "type": "string"
+          },
+          "age 5-24": {
+            "type": "number"
+          },
+          "age 25-49": {
+            "type": "number"
+          },
+          "age 50-64": {
+            "type": "number"
+          },
+          "age 64+": {
+            "type": "number"
+          },
+          "totalILI": {
+            "type": "number"
+          },
+          "totalPatients": {
+            "type": "number"
+          },
+          "percentUnweightedILI": {
+            "type": "number"
+          },
+          "percentWeightedILI": {
+            "type": "number"
+          }
+        }
+      },
+      "influenzaUSCL": {
+        "properties": {
+          "updated": {
+            "type":  "number"
+          },
+          "source": {
+            "type": "string"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/definitions/USCL"
+            }
+          }
+        }
+      },
+      "USCL": {
+        "properties": {
+          "week": {
+            "type": "string"
+          },
+          "totalA": {
+            "type": "number"
+          },
+          "totalB": {
+            "type": "number"
+          },
+          "percentPositiveA": {
+            "type": "number"
+          },
+          "percentPositiveB": {
+            "type": "number"
+          },
+          "totalTests": {
+            "type": "number"
+          },
+          "percentPositive": {
+            "type": "number"
+          }
+        }
+      },
+      "influenzaUSPHL": {
+        "properties": {
+          "updated": {
+            "type":  "number"
+          },
+          "source": {
+            "type": "string"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/definitions/USPHL"
+            }
+          }
+        }
+      },
+      "USPHL": {
+        "properties": {
+          "week": {
+            "type": "string"
+          },
+          "A(H3N2v)": {
+            "type": "number"
+          },
+          "A(H1N1)": {
+            "type": "number"
+          },
+          "A(H3)": {
+            "type": "number"
+          },
+          "A(unable to sub-type)+": {
+            "type": "number"
+          },
+          "A(Subtyping not performed)": {
+            "type": "number"
+          },
+          "B": {
+            "type": "number"
+          },
+          "BVIC": {
+            "type": "number"
+          },
+          "totalTests": {
+            "type": "number"
           }
         }
       },
@@ -1376,5 +1560,5 @@
       "description": "Find out more about this API",
       "url": "https://github.com/NovelCovid/API"
     }
-  }}
+}
   

--- a/routes/instances.js
+++ b/routes/instances.js
@@ -11,6 +11,7 @@ const nytData = require('../scrapers/covid-19/nytData');
 const appleData = require('../scrapers/covid-19/appleMobilityData');
 const govData = require('../scrapers/covid-19/govScrapers/getGovData');
 const getEbola = require('../scrapers/ebola/getEbola');
+const getCDCDInfluenzaData = require('../scrapers/influenza/getCDC');
 
 // KEYS
 const { config, keys, port } = require('../config');
@@ -57,6 +58,10 @@ module.exports = {
 		excecuteScraperEbola: async () => {
 			await getEbola(keys, redis);
 			logger.info('Finished Ebola scraping!');
+		},
+		excecuteScraperInfluenza: async () => {
+			await getCDCDInfluenzaData(keys, redis);
+			logger.info('Finished CDC Influenza scraping!');
 		}
 	}
 };

--- a/routes/v3/influenza/apiInfluenza.js
+++ b/routes/v3/influenza/apiInfluenza.js
@@ -1,0 +1,20 @@
+// eslint-disable-next-line new-cap
+const router = require('express').Router();
+const { redis, keys } = require('../../instances');
+
+router.get('/v3/influenza/CDC/ILINet', async (req, res) => {
+	const data = JSON.parse(await redis.get(keys.influenza_ILINET));
+	res.send(data);
+});
+
+router.get('/v3/influenza/CDC/USPHL', async (req, res) => {
+	const data = JSON.parse(await redis.get(keys.influenza_USPHL));
+	res.send(data);
+});
+
+router.get('/v3/influenza/CDC/USCL', async (req, res) => {
+	const data = JSON.parse(await redis.get(keys.influenza_USCL));
+	res.send(data);
+});
+
+module.exports = router;

--- a/scrapers/ebola/getEbola.js
+++ b/scrapers/ebola/getEbola.js
@@ -48,7 +48,7 @@ const ebolaData = async (keys, redis) => {
 		redis.set(keys.ebola_ecdc, JSON.stringify(data));
 		logger.info(`Updated ebola data: ${provinces.length} provinces`);
 	} catch (err) {
-		logger.err('Error: Requesting Canada Gov Data failed!', err);
+		logger.err('Error: Requesting Ebola ECDC Data failed!', err);
 	}
 };
 

--- a/scrapers/influenza/getCDC.js
+++ b/scrapers/influenza/getCDC.js
@@ -15,7 +15,6 @@ const USCLColumns = ['week', 'totalA', 'totalB', 'percentPositiveA', 'percentPos
 
 /**
  * Return object reflecting a row of data from a CDC table
- * @param 	{number} 	_ 		    Index getting passed when using .map()
  * @param 	{Object} 	row		    The row to extract data from
  * @param 	{Array} 	columns	    Respective columns for row being passed in
  * @returns {Object}				Influenza data for a week with entries for each column in @param columns

--- a/scrapers/influenza/getCDC.js
+++ b/scrapers/influenza/getCDC.js
@@ -3,12 +3,15 @@ const cheerio = require('cheerio');
 const logger = require('../../utils/logger');
 const { getCurrentWeek } = require('../../utils/dateTimeUtils');
 
-const ILINetColumns = ['week', 'age 0-4', 'age 5-24', 'age 25-49', 'age 50-64', 'age 64+', 'totalILI', 'totalPatients', 'percentUnweightedILI', '% Weighted ILI'];
+const weekNumber = getCurrentWeek() - 2;
+
+const ILINetURL = `https://www.cdc.gov/flu/weekly/weeklyarchives2019-2020/data/senAllregt${weekNumber}.html`;
+const USPHLURL = `https://www.cdc.gov/flu/weekly/weeklyarchives2019-2020/data/whoAllregt_phl${weekNumber}.html`;
+const USCLURL = `https://www.cdc.gov/flu/weekly/weeklyarchives2019-2020/data/whoAllregt_cl${weekNumber}.html`;
+
+const ILINetColumns = ['week', 'age 0-4', 'age 5-24', 'age 25-49', 'age 50-64', 'age 64+', 'totalILI', 'totalPatients', 'percentUnweightedILI', 'percentWeighted ILI'];
 const USPHLColumns = ['week', 'A(H3N2v)', 'A(H1N1)', 'A(H3)', 'A(unable to sub-type)', 'A(Subtyping not performed)', 'B', 'BVIC', 'totalTests'];
 const USCLColumns = ['week', 'totalA', 'totalB', 'percentPositiveA', 'percentPositiveB', 'totalTests', 'percentPositive'];
-
-const weekNumber = getCurrentWeek();
-console.log(weekNumber);
 
 /**
  * Return object reflecting a row of data from a CDC table
@@ -18,21 +21,51 @@ console.log(weekNumber);
  * @returns {Object}				Influenza data for a week with entries for each column in @param columns
  */
 const mapRows = (_, row, columns) => {
-	const province = { };
+	const week = { };
 	cheerio(row).children('td').each((index, cell) => {
 		cell = cheerio.load(cell);
+		const cellContents = cell.text();
 		switch (index) {
 			case 0: {
-				province[columns[index]] = cell.text() === 'Grand Total' ? 'Total' : cell.text();
-				break;
-			}
-			case 3: {
+				week[columns[index]] = `${cell.text().slice(0, 4)} - ${cell.text().slice(4)}/52`;
 				break;
 			}
 			default: {
-				province[columns[index]] = parseInt(cell.text().replace(/,/g, '')) || null;
+				if (cellContents.includes('.')) week[columns[index]] = parseFloat(cellContents);
+				else week[columns[index]] = parseInt(cell.text());
 			}
 		}
 	});
-	return province;
+	return week;
 };
+
+/**
+ * Scrapes data from table on CDC website and stores data in redis
+ * @param {string} url 	CDC URL to scrape
+ * @param {Object} columns Corresponding columns for table
+ * @param {string} key Redis key to store data at
+ * @param {Object} redis Redis instance
+ */
+const scrapeTable = async (url, columns, key, redis) => {
+	try {
+		const html = cheerio.load((await axios.get(url)).data);
+		const tableData = html(`table`).children('tr').slice(1).map((_, row) => mapRows(_, row, columns)).get();
+		const data = {
+			updated: Date.now(),
+			source: 'www.cdc.gov/flu',
+			data: tableData
+		};
+		redis.set(key, JSON.stringify(data));
+		logger.info(`Updated ${key} data: ${tableData.length} weeks`);
+	} catch (err) {
+		logger.err(`Error: Requesting CDC:${key} Data failed!`, err);
+	}
+};
+
+const getCDCDInfluenzaData = async (keys, redis) => {
+	await scrapeTable(ILINetURL, ILINetColumns, keys.influenza_ILINET, redis);
+	await scrapeTable(USPHLURL, USPHLColumns, keys.influenza_USPHL, redis);
+	await scrapeTable(USCLURL, USCLColumns, keys.influenza_USCL, redis);
+};
+
+module.exports = getCDCDInfluenzaData;

--- a/scrapers/influenza/getCDC.js
+++ b/scrapers/influenza/getCDC.js
@@ -1,0 +1,38 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+const logger = require('../../utils/logger');
+const { getCurrentWeek } = require('../../utils/dateTimeUtils');
+
+const ILINetColumns = ['week', 'age 0-4', 'age 5-24', 'age 25-49', 'age 50-64', 'age 64+', 'totalILI', 'totalPatients', 'percentUnweightedILI', '% Weighted ILI'];
+const USPHLColumns = ['week', 'A(H3N2v)', 'A(H1N1)', 'A(H3)', 'A(unable to sub-type)', 'A(Subtyping not performed)', 'B', 'BVIC', 'totalTests'];
+const USCLColumns = ['week', 'totalA', 'totalB', 'percentPositiveA', 'percentPositiveB', 'totalTests', 'percentPositive'];
+
+const weekNumber = getCurrentWeek();
+console.log(weekNumber);
+
+/**
+ * Return object reflecting a row of data from a CDC table
+ * @param 	{number} 	_ 		    Index getting passed when using .map()
+ * @param 	{Object} 	row		    The row to extract data from
+ * @param 	{Array} 	columns	    Respective columns for row being passed in
+ * @returns {Object}				Influenza data for a week with entries for each column in @param columns
+ */
+const mapRows = (_, row, columns) => {
+	const province = { };
+	cheerio(row).children('td').each((index, cell) => {
+		cell = cheerio.load(cell);
+		switch (index) {
+			case 0: {
+				province[columns[index]] = cell.text() === 'Grand Total' ? 'Total' : cell.text();
+				break;
+			}
+			case 3: {
+				break;
+			}
+			default: {
+				province[columns[index]] = parseInt(cell.text().replace(/,/g, '')) || null;
+			}
+		}
+	});
+	return province;
+};

--- a/scrapers/influenza/getCDC.js
+++ b/scrapers/influenza/getCDC.js
@@ -48,7 +48,7 @@ const mapRows = (row, columns) => {
 const scrapeTable = async (url, columns, key, redis) => {
 	try {
 		const html = cheerio.load((await axios.get(url)).data);
-		const tableData = html(`table`).children('tr').slice(1).map((row) => mapRows(row, columns)).get();
+		const tableData = html(`table`).children('tr').slice(1).map((_, row) => mapRows(row, columns)).get();
 		const data = {
 			updated: Date.now(),
 			source: 'www.cdc.gov/flu',

--- a/scrapers/influenza/getCDC.js
+++ b/scrapers/influenza/getCDC.js
@@ -9,7 +9,7 @@ const ILINetURL = `https://www.cdc.gov/flu/weekly/weeklyarchives2019-2020/data/s
 const USPHLURL = `https://www.cdc.gov/flu/weekly/weeklyarchives2019-2020/data/whoAllregt_phl${weekNumber}.html`;
 const USCLURL = `https://www.cdc.gov/flu/weekly/weeklyarchives2019-2020/data/whoAllregt_cl${weekNumber}.html`;
 
-const ILINetColumns = ['week', 'age 0-4', 'age 5-24', 'age 25-49', 'age 50-64', 'age 64+', 'totalILI', 'totalPatients', 'percentUnweightedILI', 'percentWeighted ILI'];
+const ILINetColumns = ['week', 'age 0-4', 'age 5-24', 'age 25-49', 'age 50-64', 'age 64+', 'totalILI', 'totalPatients', 'percentUnweightedILI', 'percentWeightedILI'];
 const USPHLColumns = ['week', 'A(H3N2v)', 'A(H1N1)', 'A(H3)', 'A(unable to sub-type)', 'A(Subtyping not performed)', 'B', 'BVIC', 'totalTests'];
 const USCLColumns = ['week', 'totalA', 'totalB', 'percentPositiveA', 'percentPositiveB', 'totalTests', 'percentPositive'];
 

--- a/scrapers/influenza/getCDC.js
+++ b/scrapers/influenza/getCDC.js
@@ -20,7 +20,7 @@ const USCLColumns = ['week', 'totalA', 'totalB', 'percentPositiveA', 'percentPos
  * @param 	{Array} 	columns	    Respective columns for row being passed in
  * @returns {Object}				Influenza data for a week with entries for each column in @param columns
  */
-const mapRows = (_, row, columns) => {
+const mapRows = (row, columns) => {
 	const week = { };
 	cheerio(row).children('td').each((index, cell) => {
 		cell = cheerio.load(cell);
@@ -49,7 +49,7 @@ const mapRows = (_, row, columns) => {
 const scrapeTable = async (url, columns, key, redis) => {
 	try {
 		const html = cheerio.load((await axios.get(url)).data);
-		const tableData = html(`table`).children('tr').slice(1).map((_, row) => mapRows(_, row, columns)).get();
+		const tableData = html(`table`).children('tr').slice(1).map((row) => mapRows(row, columns)).get();
 		const data = {
 			updated: Date.now(),
 			source: 'www.cdc.gov/flu',

--- a/server.js
+++ b/server.js
@@ -97,6 +97,7 @@ app.use(require('./routes/v3/covid-19/apiNYT'));
 app.use(require('./routes/v3/covid-19/apiApple'));
 app.use(require('./routes/v3/covid-19/apiGov'));
 app.use(require('./routes/v3/ebola/apiEbola'));
+app.use(require('./routes/v3/influenza/apiInfluenza'));
 
 app.listen(port, () => logger.info(`Your app is listening on port ${port}`));
 

--- a/serverScraper.js
+++ b/serverScraper.js
@@ -1,10 +1,11 @@
-const { scraper: { executeScraper, executeScraperNYTData, excecuteScraperAppleData, excecuteScraperGov, excecuteScraperEbola }, config } = require('./routes/instances');
+const { scraper: { executeScraper, executeScraperNYTData, excecuteScraperAppleData, excecuteScraperGov, excecuteScraperEbola, excecuteScraperInfluenza }, config } = require('./routes/instances');
 
 executeScraper();
 executeScraperNYTData();
 excecuteScraperAppleData();
 excecuteScraperGov();
 excecuteScraperEbola();
+excecuteScraperInfluenza();
 
 // Update Worldometer and Johns Hopkins data every 10 minutes
 setInterval(executeScraper, config.interval);
@@ -14,5 +15,7 @@ setInterval(executeScraperNYTData, config.nyt_interval);
 setInterval(excecuteScraperAppleData, config.apple_interval);
 // Update Government data every  24 hours
 setInterval(excecuteScraperGov, config.gov_interval);
-// Update Government data every  24 hours
+// Update Ebola data every  24 hours
 setInterval(excecuteScraperEbola, config.ebola_interval);
+// Update CDC data every  24 hours
+setInterval(excecuteScraperInfluenza, config.CDC_interval);

--- a/tests/mochaSetup.spec.js
+++ b/tests/mochaSetup.spec.js
@@ -1,4 +1,4 @@
-const { scraper: { executeScraper, executeScraperNYTData, excecuteScraperAppleData, excecuteScraperGov, excecuteScraperEbola }, redis } = require('../routes/instances');
+const { scraper: { executeScraper, executeScraperNYTData, excecuteScraperAppleData, excecuteScraperGov, excecuteScraperEbola, excecuteScraperInfluenza }, redis } = require('../routes/instances');
 const logger = require('../utils/logger');
 
 // eslint-disable-next-line
@@ -11,5 +11,6 @@ before(async () => {
 	await excecuteScraperAppleData();
 	await excecuteScraperGov();
 	await excecuteScraperEbola();
+	await excecuteScraperInfluenza();
 	logger.info('Scraping finished.');
 });

--- a/tests/v3/influenza/api_influenza.spec.js
+++ b/tests/v3/influenza/api_influenza.spec.js
@@ -1,0 +1,129 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const app = require('../../../server');
+const { testBasicProperties } = require('../../testingFunctions');
+
+chai.use(chaiHttp);
+
+describe('TESTING /v3/influenza/CDC', () => {
+	it('/v3/influenza/cdc/ILINet correct properties', (done) => {
+		chai.request(app)
+			.get('/v3/influenza/cdc/ILINet')
+			.end((err, res) => {
+				testBasicProperties(err, res, 200, 'object');
+				res.body.should.have.property('updated');
+				res.body.should.have.property('source');
+				res.body.should.have.property('data');
+				done();
+			});
+    });
+
+    it('/v3/influenza/cdc/ILINet correct data properties set', (done) => {
+		chai.request(app)
+			.get('/v3/influenza/cdc/ILINet')
+			.end((err, res) => {
+				testBasicProperties(err, res, 200, 'object');
+                res.body.data.forEach((row) => {
+                    row.should.have.property('week');
+                    row.should.be.a('string');
+                    row.should.have.property('age 0-4');
+                    row['age 0-4'].should.be.at.least(0);
+                    row.should.have.property('age 5-24');
+                    row['age 5-24'].should.be.at.least(0);
+                    row.should.have.property('age 25-49');
+                    row['age 25-49'].should.be.at.least(0);
+                    row.should.have.property('age 50-64');
+                    row['age 50-64'].should.be.at.least(0);
+                    row.should.have.property('age 64+');
+                    row['age 64+'].should.be.at.least(0);
+                    row.should.have.property('totalILI');
+                    row['totalILI'].should.be.at.least(0);
+                    row.should.have.property('totalPatients');
+                    row['totalPatients'].should.be.at.least(0);
+                    row.should.have.property('percentUnweightedILI');
+                    row['percentUnweightedILI'].should.be.at.least(0.0);
+                    row.should.have.property('percentWeightedILI');
+                    row['percentWeightedILI'].should.be.at.least(0.0);
+                });
+                done();
+			});
+    });
+
+    it('/v3/influenza/cdc/USPHL correct properties', (done) => {
+		chai.request(app)
+			.get('/v3/influenza/cdc/USPHL')
+			.end((err, res) => {
+				testBasicProperties(err, res, 200, 'object');
+				res.body.should.have.property('updated');
+				res.body.should.have.property('source');
+				res.body.should.have.property('data');
+				done();
+			});
+    });
+
+    it('/v3/influenza/cdc/USPHL correct data properties set', (done) => {
+		chai.request(app)
+			.get('/v3/influenza/cdc/USPHL')
+			.end((err, res) => {
+				testBasicProperties(err, res, 200, 'object');
+                res.body.data.forEach((row) => {
+                    row.should.have.property('week');
+                    row.should.be.a('string');
+                    row.should.have.property('A(H3N2v)');
+                    row['A(H3N2v)'].should.be.at.least(0);
+                    row.should.have.property('A(H1N1)');
+                    row['A(H1N1)'].should.be.at.least(0);
+                    row.should.have.property('A(H3)');
+                    row['A(H3)'].should.be.at.least(0);
+                    row.should.have.property('A(unable to sub-type)');
+                    row['A(unable to sub-type)'].should.be.at.least(0);
+                    row.should.have.property('A(Subtyping not performed)');
+                    row['A(Subtyping not performed)'].should.be.at.least(0);
+                    row.should.have.property('B');
+                    row['B'].should.be.at.least(0);
+                    row.should.have.property('BVIC');
+                    row['BVIC'].should.be.at.least(0);
+                    row.should.have.property('totalTests');
+                    row['totalTests'].should.be.at.least(0);
+                });
+                done();
+			});
+    });
+
+    it('/v3/influenza/cdc/USCL correct properties', (done) => {
+		chai.request(app)
+			.get('/v3/influenza/cdc/USCL')
+			.end((err, res) => {
+				testBasicProperties(err, res, 200, 'object');
+				res.body.should.have.property('updated');
+				res.body.should.have.property('source');
+				res.body.should.have.property('data');
+				done();
+			});
+    });
+
+    it('/v3/influenza/cdc/USCL correct data properties set', (done) => {
+		chai.request(app)
+			.get('/v3/influenza/cdc/USCL')
+			.end((err, res) => {
+				testBasicProperties(err, res, 200, 'object');
+                res.body.data.forEach((row) => {
+                    row.should.have.property('week');
+                    row.should.be.a('string');
+                    row.should.have.property('totalA');
+                    row['totalA'].should.be.at.least(0);
+                    row.should.have.property('totalB');
+                    row['totalB'].should.be.at.least(0);
+                    row.should.have.property('percentPositiveA');
+                    row['percentPositiveA'].should.be.at.least(0);
+                    row.should.have.property('percentPositiveB');
+                    row['percentPositiveB'].should.be.at.least(0);
+                    row.should.have.property('totalTests');
+                    row['totalTests'].should.be.at.least(0);
+                    row.should.have.property('percentPositive');
+                    row['percentPositive'].should.be.at.least(0);
+                });
+                done();
+			});
+    });
+});

--- a/tests/v3/influenza/api_influenza.spec.js
+++ b/tests/v3/influenza/api_influenza.spec.js
@@ -25,7 +25,7 @@ describe('TESTING /v3/influenza/CDC', () => {
 				testBasicProperties(err, res, 200, 'object');
                 res.body.data.forEach((row) => {
                     row.should.have.property('week');
-                    row.should.be.a('string');
+                    row.week.should.be.a('string');
                     row.should.have.property('age 0-4');
                     row['age 0-4'].should.be.at.least(0);
                     row.should.have.property('age 5-24');
@@ -68,7 +68,7 @@ describe('TESTING /v3/influenza/CDC', () => {
 				testBasicProperties(err, res, 200, 'object');
                 res.body.data.forEach((row) => {
                     row.should.have.property('week');
-                    row.should.be.a('string');
+                    row.week.should.be.a('string');
                     row.should.have.property('A(H3N2v)');
                     row['A(H3N2v)'].should.be.at.least(0);
                     row.should.have.property('A(H1N1)');
@@ -109,7 +109,7 @@ describe('TESTING /v3/influenza/CDC', () => {
 				testBasicProperties(err, res, 200, 'object');
                 res.body.data.forEach((row) => {
                     row.should.have.property('week');
-                    row.should.be.a('string');
+                    row.week.should.be.a('string');
                     row.should.have.property('totalA');
                     row['totalA'].should.be.at.least(0);
                     row.should.have.property('totalB');

--- a/utils/dateTimeUtils.js
+++ b/utils/dateTimeUtils.js
@@ -1,0 +1,21 @@
+/**
+ * Get current integer week of year to pass in as URL param for CDC
+ * Source: https://weeknumber.net/how-to/javascript
+ * @returns {number} 	Number week (e.g. 1 for January 4th)
+ */
+Date.prototype.getWeek = function getWeek() {
+	var date = new Date(this.getTime());
+	date.setHours(0, 0, 0, 0);
+	// Thursday in current week decides the year.
+	date.setDate(date.getDate() + 3 - ((date.getDay() + 6) % 7));
+	// January 4 is always in week 1.
+	var week1 = new Date(date.getFullYear(), 0, 4);
+	// Adjust to Thursday in week 1 and count number of weeks from date to week1.
+	return 1 + Math.round((((date.getTime() - week1.getTime()) / 86400000) - 3 + ((week1.getDay() + 6) % 7)) / 7);
+};
+
+const getCurrentWeek = () => new Date().getWeek();
+
+module.exports = {
+	getCurrentWeek
+};


### PR DESCRIPTION
## New Endpoints
- `/v3/influenza/cdc/ILINet` get's influenza like-illness-reports
- `/v3/influenza/cdc/USPHL` get's influenza case reports from US Public health labs
- `/v3/influenza/cdc/USCL` get's influenza case reports from US clinical labs

## Scraping 
- Takes place once every 24h
- File can be found in `scrapers/influenza`
## Testing
For each endpoint there is one set of tests, each containing two cases
1. Make sure correct properties are set
2. Check that properties have correct types and are filled

## Docs
They are there
